### PR TITLE
fixbug#1644

### DIFF
--- a/src/js/text/index.js
+++ b/src/js/text/index.js
@@ -357,6 +357,8 @@ Text.prototype = {
 
         // 粘贴文字
         $textElem.on('paste', e => {
+            // 粘贴前先更新选区
+            editor.selection.saveRange()
             if (UA.isIE()) {
                 return
             } else {


### PR DESCRIPTION
根据1644描述修改粘贴全选文本有可能出现之前选中文本不删除的情况。代码已经测试过，不对其他代码产生影响。