### PR TITLE
url检验失败后支持不弹对话框

### DIFF
--- a/src/js/menus/link/index.js
+++ b/src/js/menus/link/index.js
@@ -142,7 +142,7 @@ Link.prototype = {
         }
         if (checkResult === true) {
             editor.cmd.do('insertHTML', `<a href="${link}" target="_blank">${text}</a>`)
-        } else {
+        } else if (checkResult) {
             alert(checkResult)
         }
     },


### PR DESCRIPTION
url校验失败后返回如果不是true，则alert，不利于扩展。 增加判断条件，允许校验失败后也不弹对话框（比如false， 或空字符串等值）。

应用场景： 使用方通过confirm去确认， 这里就没必要二次弹框了。