### PR TITLE
fix: 粘贴文字中间空格保留

### DIFF
--- a/src/text/paste/parse-html.ts
+++ b/src/text/paste/parse-html.ts
@@ -146,8 +146,9 @@ function parseHtml(html: string, filterStyle: boolean = true, ignoreImg: boolean
             resultArr.push(html)
         },
         characters(str: string) {
-            str = str.trim()
-            if (!str) return
+            if (/^\s*$/.test(str)) {
+                return
+            }
 
             // 忽略的标签
             // 如果复制拿到的内容是 `<body><html>这种形式无法成功粘贴</html></body>`


### PR DESCRIPTION
## 遇到问题    
*当一串文字中间有部分有加粗或者下划线，且左右两侧有空格时，复制该段文字，然后粘贴，中间的空格部分会被清空。官网可复现。*
## 预期  
*执行以上操作，粘贴的文字中间空格部分保留。*
## 是否进行自测
*是*
