### PR TITLE
fix: 最后一行文本看不见

### DIFF
--- a/src/editor/init-fns/set-full-screen.ts
+++ b/src/editor/init-fns/set-full-screen.ts
@@ -27,7 +27,9 @@ export const setFullScreen = (editor: Editor) => {
     $iconElem.addClass(iconExitFullScreenText)
     $editorParent.addClass(classfullScreenEditor)
     $editorParent.css('z-index', config.zIndexFullScreen)
-    $textContainerElem.css('height', '100%')
+    const bar = $toolbarElem.getBoundingClientRect()
+    const h = window.innerHeight - bar.height
+    $textContainerElem.css('height', `${h}px`)
 }
 
 /**


### PR DESCRIPTION
## 遇到问题  
*当最后一行是文字，设置全屏出现滚动条时，最后一行文本不可见。*
## 预期  
*设置全屏时，最后一行文本在可视区域内可见。*
## 是否进行自测  
*是*