### PR TITLE
fix: 失去焦点tooltip不消失

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -179,7 +179,6 @@ class Editor {
     public destroy(): void {
         // 调用钩子函数
         this.beforeDestroyHooks.forEach(fn => fn.call(this))
-
         // 销毁 DOM 节点
         this.$toolbarElem.remove()
         this.$textContainerElem.remove()

--- a/src/editor/init-fns/bind-event.ts
+++ b/src/editor/init-fns/bind-event.ts
@@ -56,10 +56,7 @@ function _bindFocusAndBlur(editor: Editor): void {
             if (isToolbar && !isMenu) {
                 return
             }
-
-            if (editor.isFocus) {
-                _blurHandler(editor)
-            }
+            _blurHandler(editor)
             editor.isFocus = false
         } else {
             if (!editor.isFocus) {
@@ -103,6 +100,7 @@ function _blurHandler(editor: Editor) {
     const config = editor.config
     const onblur = config.onblur
     const currentHtml = editor.txt.html() || ''
+    editor.txt.eventHooks.onBlurEvents.forEach(fn => fn())
     onblur(currentHtml)
 }
 

--- a/src/menus/menu-constructors/Tooltip.ts
+++ b/src/menus/menu-constructors/Tooltip.ts
@@ -31,7 +31,6 @@ class Tooltip {
         this.conf = conf
         this._show = false
         this._isInsertTextContainer = false
-
         // 定义 container
         const $container = $('<div></div>')
         $container.addClass('w-e-tooltip')
@@ -167,6 +166,9 @@ class Tooltip {
         }
 
         this._show = true
+
+        editor.beforeDestroy(this.remove.bind(this))
+        editor.txt.eventHooks.onBlurEvents.push(this.remove.bind(this))
     }
 
     /**

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -13,9 +13,10 @@ import getHtmlByNodeList from './getHtmlByNodeList'
 /** 按键函数 */
 type KeyBoardHandler = (event: KeyboardEvent) => unknown
 /** 普通事件回调 */
-type EventHandler = (event: Event) => unknown
+type EventHandler = (event?: Event) => unknown
 // 各个事件钩子函数
 type TextEventHooks = {
+    onBlurEvents: EventHandler[]
     changeEvents: (() => void)[] // 内容修改时
     dropEvents: ((event: DragEvent) => unknown)[]
     clickEvents: EventHandler[]
@@ -64,6 +65,7 @@ class Text {
         this.editor = editor
 
         this.eventHooks = {
+            onBlurEvents: [],
             changeEvents: [],
             dropEvents: [],
             clickEvents: [],

--- a/test/unit/menus/tooltip.test.ts
+++ b/test/unit/menus/tooltip.test.ts
@@ -43,6 +43,7 @@ test('点击 tooltip', () => {
 })
 
 test('tooltip 显示和隐藏', () => {
+    tooltip.create()
     expect(tooltip.isShow).toBe(true)
 
     tooltip.remove()


### PR DESCRIPTION
解决bug编辑器失去焦点和销毁tooltip不消失问题

bind-event.ts 去掉 if(editor.focus) 原因是有些地方用到了event.stopPropagation方法导致失去焦点事件无法触发

在失去焦点和销毁编辑器的时候调用editor.txt.eventHooks.toolbarClickEvents.forEach(fn => fn(event))钩子来移除tooltip