### PR TITLE
fix: 禁止嵌套编辑器/初始化时追加子节点

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -16,6 +16,7 @@ import bindEvent from './init-fns/bind-event'
 import i18nextInit from './init-fns/i18next-init'
 import initFullScreen, { setUnFullScreen, setFullScreen } from './init-fns/set-full-screen'
 import scrollToHead from './init-fns/scroll-to-head'
+import validateSelectorParams from './init-fns/validate-selector-params'
 import ZIndex from './z-index'
 import Change from './change/index'
 import History from './history/index'
@@ -49,6 +50,7 @@ class Editor {
     public $toolbarElem: DomElement
     public $textContainerElem: DomElement
     public $textElem: DomElement
+    public $containerElem: DomElement[]
     public toolbarElemId: string
     public textElemId: string
     public isFocus: boolean
@@ -79,21 +81,21 @@ class Editor {
      * @param textSelector 文本区域 DOM selector
      */
     constructor(toolbarSelector: DomElementSelector, textSelector?: DomElementSelector) {
+        // 校验传入的 DOM selector 参数
+        validateSelectorParams(toolbarSelector, textSelector)
+
         // id，用以区分单个页面不同的编辑器对象
         this.id = `wangEditor-${EDITOR_ID++}`
 
         this.toolbarSelector = toolbarSelector
         this.textSelector = textSelector
 
-        if (toolbarSelector == null) {
-            throw new Error('错误：初始化编辑器时候未传入任何参数，请查阅文档')
-        }
-
         // 属性的默认值，后面可能会再修改
         // 默认配置 - 当一个页面有多个编辑器的时候，因为 JS 的特性(引用类型)会导致多个编辑器的 config 引用是同一个，所以需要 深度克隆 断掉引用
         this.config = deepClone(defaultConfig)
         this.$toolbarElem = $('<div></div>')
         this.$textContainerElem = $('<div></div>')
+        this.$containerElem = [this.$toolbarElem]
         this.$textElem = $('<div></div>')
         this.toolbarElemId = ''
         this.textElemId = ''

--- a/src/editor/init-fns/validate-selector-params.ts
+++ b/src/editor/init-fns/validate-selector-params.ts
@@ -1,0 +1,36 @@
+import $, { DomElementSelector, DomElement } from '../../utils/dom-core'
+
+/**
+ * 校验 Editor 的constructor 参数
+ * @param toolbarSelector 工具栏 DOM selector
+ * @param textSelector 文本区域 DOM selector
+ * @author lichen
+ */
+export default function validateSelectorParams(
+    toolbarSelector: DomElementSelector,
+    textSelector?: DomElementSelector
+): void {
+    // 判断 工具栏 DOM selector 是否存在
+    if (toolbarSelector == null) {
+        throw new Error('错误：初始化编辑器时候未传入任何参数，请查阅文档')
+    }
+
+    const $toolbarSelector = $(toolbarSelector)
+
+    // 收集最外层的container 元素
+    const $containerElem: DomElement[] = [$toolbarSelector]
+    if (textSelector != null) {
+        $containerElem.push($(textSelector))
+    }
+
+    // 判断当前传入的dom selector 与 已存在的编辑器区域是否存在嵌套关系 最多 O(2) 次 循环
+    const $readyElemArray = $('[data-w-e-ready=true]').elems
+    for (const $readyElem of $readyElemArray) {
+        for (const $paramElem of $containerElem) {
+            const [$param] = $paramElem.elems
+            if ($param == null) continue
+            if ($readyElem.contains($param) || $param.contains($readyElem))
+                throw new Error('错误: 不支持嵌套生成 编辑器')
+        }
+    }
+}

--- a/test/unit/config/menus.test.ts
+++ b/test/unit/config/menus.test.ts
@@ -5,8 +5,9 @@
 
 import createEditor from '../../helpers/create-editor'
 
+let id = 1
 test('菜单数量', () => {
-    const editor = createEditor(document, 'div1')
+    const editor = createEditor(document, `div${id++}`)
     const menus = editor.config.menus
     const $toolbarChildren = editor.$toolbarElem.childNodes() || []
     let childrenLen = $toolbarChildren.length - 1
@@ -17,7 +18,7 @@ test('菜单数量', () => {
 
 // 各个菜单的配置，随后开发的时候再加
 test('菜单 exclude', () => {
-    const editor = createEditor(document, 'div1', '', {
+    const editor = createEditor(document, `div${id++}`, '', {
         excludeMenus: ['bold'],
     })
     const menus = editor.config.menus

--- a/test/unit/editor/auto-focus.test.ts
+++ b/test/unit/editor/auto-focus.test.ts
@@ -11,14 +11,15 @@ const $SPAN = $(`<span>${TEXT}</span>`)
 const $P = $('<p></p>')
 $P.append($SPAN)
 
+let id = 1
 test('auto-focus: false', () => {
-    createEditor(document, 'div1', '', { focus: false })
+    createEditor(document, `div${id++}`, '', { focus: false })
     const rangeCount = window?.getSelection()?.rangeCount
     expect(rangeCount).toBe(0)
 })
 
 test('auto-focus: true', () => {
-    createEditor(document, 'div1')
+    createEditor(document, `div${id++}`)
     const rangeCount = window?.getSelection()?.rangeCount
     expect(rangeCount).toBe(1)
 })

--- a/test/unit/editor/create-editor.test.ts
+++ b/test/unit/editor/create-editor.test.ts
@@ -5,19 +5,20 @@
 
 import createEditor from '../../helpers/create-editor'
 
+let id = 1
 test('创建一个编辑器实例', () => {
-    const editor = createEditor(document, 'div1')
+    const editor = createEditor(document, `div${id++}`)
     expect(editor.id).not.toBeNull()
 })
 
 test('创建一个编辑器实例，toolbar 和 text 分离', () => {
-    const editor = createEditor(document, 'div1', 'div2')
+    const editor = createEditor(document, `div${id++}`, `div${id++}`)
     expect(editor.id).not.toBeNull()
 })
 
 test('一个页面创建多个编辑器实例', () => {
-    const editor1 = createEditor(document, 'div1')
-    const editor2 = createEditor(document, 'div2')
+    const editor1 = createEditor(document, `div${id++}`)
+    const editor2 = createEditor(document, `div${id++}`)
     expect(editor1.id).not.toBeNull()
     expect(editor2.id).not.toBeNull()
 })

--- a/test/unit/editor/disable.test.ts
+++ b/test/unit/editor/disable.test.ts
@@ -4,9 +4,10 @@ import disableInit from '../../../src/editor/disable'
 
 let editor: Editor
 
+let id = 1
 describe('Editor disable', () => {
     beforeEach(() => {
-        editor = createEditor(document, 'div1')
+        editor = createEditor(document, `div${id++}`)
     })
 
     test('编辑器可以被禁用', () => {

--- a/test/unit/editor/history/compile.test.ts
+++ b/test/unit/editor/history/compile.test.ts
@@ -34,10 +34,11 @@ function generateCompileData(mutationList: MutationRecord[]) {
 }
 
 const originalValue = UA.isFirefox
+let id = 1
 
 describe('Editor history compile', () => {
     beforeEach(() => {
-        editor = createEditor(document, 'div1')
+        editor = createEditor(document, `div${id++}`)
     })
 
     afterEach(() => {
@@ -74,7 +75,7 @@ describe('Editor history compile', () => {
         const observer = new MutationObserver((mutationList: MutationRecord[]) => {
             const compileData = compile(mutationList)
             expect(compileData instanceof Array).toBeTruthy()
-            expect(compileData.length).toBe(4)
+            expect(compileData.length).toBe(5)
             done()
         })
 

--- a/test/unit/editor/history/data-html.test.ts
+++ b/test/unit/editor/history/data-html.test.ts
@@ -8,9 +8,10 @@ import HtmlCache from '../../../../src/editor/history/data/html'
 
 let editor: Editor
 let htmlCache: HtmlCache
+let id = 1
 describe('Editor history html cache', () => {
     beforeEach(() => {
-        editor = createEditor(document, 'div1', '', {
+        editor = createEditor(document, `div${id++}`, '', {
             compatibleMode: () => true,
         })
 

--- a/test/unit/editor/history/decompile.test.ts
+++ b/test/unit/editor/history/decompile.test.ts
@@ -9,10 +9,11 @@ import compile from '../../../../src/editor/history/data/node/compile'
 import { restore, revoke } from '../../../../src/editor/history/data/node/decompilation'
 
 let editor: Editor
+let id = 1
 
 describe('Editor history decompile', () => {
     beforeEach(() => {
-        editor = createEditor(document, 'div1')
+        editor = createEditor(document, `div${id++}`)
     })
 
     test('可以通过revoke方法撤销编辑器设置的html', done => {

--- a/test/unit/editor/set-full-screen.test.ts
+++ b/test/unit/editor/set-full-screen.test.ts
@@ -7,9 +7,10 @@ let editor: Editor
 const FULLSCREEN_MENU_CLASS_SELECTOR = '.w-e-icon-fullscreen'
 const EDIT_CONTAINER_FULLSCREEN_CLASS = 'w-e-full-screen-editor'
 
+let id = 1
 describe('设置全屏', () => {
     beforeEach(() => {
-        editor = createEditor(document, 'div1')
+        editor = createEditor(document, `div${id++}`)
     })
 
     test('编辑器默认初始化全屏菜单', () => {
@@ -20,7 +21,7 @@ describe('设置全屏', () => {
     })
 
     test('编辑器区和菜单分离的编辑器不初始化全屏菜单', () => {
-        const seprateModeEditor = createEditor(document, 'div1', 'div2')
+        const seprateModeEditor = createEditor(document, `div${id++}`, `div${id++}`)
         const toolbarSelector = seprateModeEditor.$toolbarElem.selector as string
         const fullMenuEl = $(toolbarSelector).find(FULLSCREEN_MENU_CLASS_SELECTOR)
 
@@ -28,7 +29,9 @@ describe('设置全屏', () => {
     })
 
     test('编辑器配置 showFullScreen 为false时不初始化全屏菜单', () => {
-        const seprateModeEditor = createEditor(document, 'div1', '', { showFullScreen: false })
+        const seprateModeEditor = createEditor(document, `div${id++}`, '', {
+            showFullScreen: false,
+        })
         const toolbarSelector = seprateModeEditor.$toolbarElem.selector as string
         const fullMenuEl = $(toolbarSelector).find(FULLSCREEN_MENU_CLASS_SELECTOR)
 
@@ -40,7 +43,7 @@ describe('设置全屏', () => {
 
         const toolbarSelector = editor.$toolbarElem.elems[0].className
         const $iconElem = $(`.${toolbarSelector}`).children().last().find('i')
-        const $editorParent = $(`.${toolbarSelector}`).parent().get(0)
+        const $editorParent = editor.$containerElem[0].elems[0]
         const $textContainerElem = editor.$textContainerElem
 
         expect($iconElem.get(0).className).toContain('w-e-icon-fullscreen_exit')
@@ -58,7 +61,7 @@ describe('设置全屏', () => {
 
         const toolbarSelector = editor.$toolbarElem.elems[0].className
         const $iconElem = $(`.${toolbarSelector}`).children().last().find('i')
-        const $editorParent = $(`.${toolbarSelector}`).parent().get(0)
+        const $editorParent = editor.$containerElem[0].elems[0]
         const $textContainerElem = editor.$textContainerElem
 
         expect($iconElem.get(0).className).toContain('w-e-icon-fullscreen')

--- a/test/unit/menus/img/paste-img.test.ts
+++ b/test/unit/menus/img/paste-img.test.ts
@@ -11,6 +11,7 @@ import * as pasteEvents from '../../../../src/text/paste/paste-event'
 
 const mockFiles = [mockFile({ name: 'test.png', size: 200, mimeType: 'image/png' })]
 const mockUploadImg = jest.fn()
+let id = 1
 
 jest.mock('../../../../src/menus/img/upload-img', () => {
     return jest.fn().mockImplementation(() => {
@@ -26,7 +27,7 @@ describe('Img menu paste-img', () => {
     })
 
     test('调用 bindPasteImgEvent 方法给编辑器绑定paste事件', () => {
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
 
         bindPasteImgEvent(editor)
 
@@ -40,7 +41,7 @@ describe('Img menu paste-img', () => {
 
         mock.mockReturnValue(mockFiles)
 
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
 
         bindPasteImgEvent(editor)
 
@@ -65,7 +66,7 @@ describe('Img menu paste-img', () => {
 
         mock.mockReturnValue([])
 
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
 
         bindPasteImgEvent(editor)
 
@@ -89,7 +90,7 @@ describe('Img menu paste-img', () => {
 
         mock.mockReturnValue(mockFiles)
 
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
 
         bindPasteImgEvent(editor)
 
@@ -113,7 +114,7 @@ describe('Img menu paste-img', () => {
 
         mock.mockReturnValue(mockFiles)
 
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
 
         bindPasteImgEvent(editor)
 

--- a/test/unit/text/paste-text-html.test.ts
+++ b/test/unit/text/paste-text-html.test.ts
@@ -8,9 +8,10 @@ import * as pasteEvents from '../../../src/text/paste/paste-event'
 import $ from '../../../src/utils/dom-core'
 import mockCommand from '../../helpers/command-mock'
 
+let id = 1
 describe('text utils getPasteImgs test', () => {
     test('执行函数会绑定一个 pasteEvents handler', () => {
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
         const pasteEvents: Function[] = []
         pasteTextHtml(editor, pasteEvents)
 
@@ -18,7 +19,7 @@ describe('text utils getPasteImgs test', () => {
     })
 
     test('如果当前选区所在元素不存在，执行 pasteEvents 的函数直接返回', () => {
-        const editor = createEditor(document, 'div2')
+        const editor = createEditor(document, `div${id++}`)
         const pasteEventList: Function[] = []
 
         pasteTextHtml(editor, pasteEventList)
@@ -41,7 +42,7 @@ describe('text utils getPasteImgs test', () => {
         jest.spyOn(document, 'queryCommandSupported').mockImplementation(() => true)
 
         const mockPasteTextHandle = jest.fn(() => 'mock123<br>')
-        const editor = createEditor(document, 'div3', '', {
+        const editor = createEditor(document, `div${id++}`, '', {
             pasteTextHandle: mockPasteTextHandle,
         })
 
@@ -68,7 +69,7 @@ describe('text utils getPasteImgs test', () => {
 
         jest.spyOn(document, 'queryCommandSupported').mockImplementation(() => true)
 
-        const editor = createEditor(document, 'div4')
+        const editor = createEditor(document, `div${id++}`)
 
         const pasteEventList: Function[] = []
 
@@ -98,7 +99,7 @@ describe('text utils getPasteImgs test', () => {
 
         jest.spyOn(document, 'queryCommandSupported').mockImplementation(() => true)
 
-        const editor = createEditor(document, 'div4')
+        const editor = createEditor(document, `div${id++}`)
 
         const pasteEventList: Function[] = []
 
@@ -121,7 +122,7 @@ describe('text utils getPasteImgs test', () => {
 
         jest.spyOn(document, 'queryCommandSupported').mockImplementation(() => true)
 
-        const editor = createEditor(document, 'div4')
+        const editor = createEditor(document, `div${id++}`)
 
         const pasteEventList: Function[] = []
 
@@ -145,7 +146,7 @@ describe('text utils getPasteImgs test', () => {
         jest.spyOn(document, 'queryCommandSupported').mockImplementation(() => true)
 
         const mockPasteTextHandle = jest.fn(() => '<div>123</div><p></p>')
-        const editor = createEditor(document, 'div3', '', {
+        const editor = createEditor(document, `div${id++}`, '', {
             pasteTextHandle: mockPasteTextHandle,
         })
 
@@ -179,7 +180,7 @@ describe('text utils getPasteImgs test', () => {
 
         const mockPasteTextHandle = jest.fn(() => '<div>123</div><p></p>')
 
-        const editor = createEditor(document, 'div3', '', {
+        const editor = createEditor(document, `div${id++}`, '', {
             pasteTextHandle: mockPasteTextHandle,
         })
 

--- a/test/unit/text/tab-to-space.test.ts
+++ b/test/unit/text/tab-to-space.test.ts
@@ -7,10 +7,12 @@ import $ from '../../../src/utils/dom-core'
 import createEditor from '../../helpers/create-editor'
 import mockCommand from '../../helpers/command-mock'
 
+let id = 1
+
 describe('editor.text event-hooks tab-to-space test', () => {
     test('能绑定一个处理 tab 的函数', () => {
         const fn: Function[] = []
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
 
         tabHandler(editor, fn)
 
@@ -21,7 +23,7 @@ describe('editor.text event-hooks tab-to-space test', () => {
         mockCommand(document)
 
         const fn: Function[] = []
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
 
         jest.spyOn(editor.cmd, 'queryCommandSupported').mockImplementation(() => false)
 
@@ -38,7 +40,7 @@ describe('editor.text event-hooks tab-to-space test', () => {
         mockCommand(document)
 
         const fn: Function[] = []
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
 
         jest.spyOn(editor.cmd, 'queryCommandSupported').mockImplementation(() => true)
         jest.spyOn(editor.selection, 'getSelectionContainerElem').mockImplementation(
@@ -58,7 +60,7 @@ describe('editor.text event-hooks tab-to-space test', () => {
         mockCommand(document)
 
         const fn: Function[] = []
-        const editor = createEditor(document, 'div1')
+        const editor = createEditor(document, `div${id++}`)
 
         jest.spyOn(editor.cmd, 'queryCommandSupported').mockImplementation(() => true)
         const container = $('<p><br></p>')
@@ -84,7 +86,7 @@ describe('editor.text event-hooks tab-to-space test', () => {
         let fn: Function[] = []
 
         beforeEach(() => {
-            editor = createEditor(document, `div${id++}`)
+            editor = createEditor(document, `div1${id++}`)
 
             tabHandler(editor, fn)
 


### PR DESCRIPTION
分别解决两个问题 issue #2697  #2720 
1. 以抛异常的情况 去禁止嵌套生成编辑器
2. 在text 与 bar 分离时, 追加子节点而不是修改用户传入的节点
