### PR TITLE
fix:解决单引号属性parse后变undefined问题

### DIFF
--- a/src/lib/simplehtmlparser.js
+++ b/src/lib/simplehtmlparser.js
@@ -147,8 +147,8 @@ SimpleHtmlParser.prototype = {
     parseAttributes: function (sTagName, s) {
         var oThis = this
         var attrs = []
-        s.replace(this.attrRe, function (a0, a1, a2, a3, a4, a5, a6) {
-            attrs.push(oThis.parseAttribute(sTagName, a0, a1, a2, a3, a4, a5, a6))
+        s.replace(this.attrRe, function (a0, a1, a2, a3, a4, a5, a6, a7) {
+            attrs.push(oThis.parseAttribute(sTagName, a0, a1, a2, a3, a4, a5, a6, a7))
         })
         return attrs
     },


### PR DESCRIPTION
解决parseAttributes正则匹配后参数少传了一位，导致parseAttribute中arguments[8]取到的值是undefined，最终标签属性设置错误问题。

## 遇到的问题

*在复制一个带样式的内容到富文本框时样式丢失，调试发现是parseAttributes方法在正则匹配后处理参数时少传了一位，导致后面parseAttribute中arguments[8]取到的值是undefined

## 我的预期

在关闭样式过滤功能后复制的带样式内容能够正确显示样式

## 复现场景

拷贝一份样式或属性带有单引号的内容（例如从world中拷贝一个表格）到富文本中，样式和属性丢失。

## 是否进行了详细的自测？

*是