### PR TITLE
fix:解决单引号属性parse后变undefined问题

### DIFF
--- a/src/lib/simplehtmlparser.js
+++ b/src/lib/simplehtmlparser.js
@@ -147,8 +147,8 @@ SimpleHtmlParser.prototype = {
     parseAttributes: function (sTagName, s) {
         var oThis = this
         var attrs = []
-        s.replace(this.attrRe, function (a0, a1, a2, a3, a4, a5, a6) {
-            attrs.push(oThis.parseAttribute(sTagName, a0, a1, a2, a3, a4, a5, a6))
+        s.replace(this.attrRe, function (a0, a1, a2, a3, a4, a5, a6, a7) {
+            attrs.push(oThis.parseAttribute(sTagName, a0, a1, a2, a3, a4, a5, a6, a7))
         })
         return attrs
     },


### PR DESCRIPTION
解决parseAttributes正则匹配后参数少传了一位，导致parseAttribute中arguments[8]取到的值是undefined，最终标签属性设置错误问题。