### PR TITLE
fix: 解决自定义菜单位置添加不对问题

### DIFF
--- a/src/editor/init-fns/init-dom.ts
+++ b/src/editor/init-fns/init-dom.ts
@@ -45,6 +45,11 @@ export default function (editor: Editor): void {
             .css('height', `${height}px`)
     } else {
         // toolbarSelector 和 textSelector 都有
+        const $customToolbar = $toolbarSelector.children()
+        // 有自定义的菜单，将自定义的菜单添加到菜单栏中
+        if ($customToolbar && $customToolbar.length) {
+            $toolbarElem.append($customToolbar)
+        }
         $toolbarSelector.append($toolbarElem)
         $(textSelector).append($textContainerElem)
         // 将编辑器区域原有的内容，暂存起来


### PR DESCRIPTION
## 遇到了什么问题

*v4.x版本toolbar新增了一层菜单容器，菜单容器下放的是菜单元素，导致在toolbar下自定义的菜单实际被添加到toolbar下与菜单容器在同一层，而非菜单容器下如下图*
![image](https://user-images.githubusercontent.com/13391396/106877016-4a171b80-6713-11eb-9f11-59cc5ca7e9ab.png)
![image](https://user-images.githubusercontent.com/13391396/106877299-91051100-6713-11eb-9cb7-2577d11c49ac.png)

## 你的预期是什么

*toolbar下自定义的菜单添加到菜单容器下，与菜单元素同一层如下图*
![image](https://user-images.githubusercontent.com/13391396/106877689-01139700-6714-11eb-9f34-e9dee469c8fe.png)

## 是否进行了详细的自测？

*是*