### PR TITLE
fix: right click will cancel the selection

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -283,7 +283,7 @@ class Text {
             $textElem.on('mouseleave', saveRange)
         })
 
-        $textElem.on('mouseup', () => {
+        $textElem.on('mouseup', (e: MouseEvent) => {
             const selection = editor.selection
             const range = selection.getRange()
 
@@ -295,7 +295,7 @@ class Text {
             if (startOffset !== endOffset && endContainer != null) {
                 range?.setStart(endContainer, endOffset)
             }
-            if(e.button===0){
+            if (e.button === 0) {
                 saveRange()
             }
             // 在编辑器区域之内完成点击，取消鼠标滑动到编辑区外面的事件

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -295,9 +295,9 @@ class Text {
             if (startOffset !== endOffset && endContainer != null) {
                 range?.setStart(endContainer, endOffset)
             }
-
-            saveRange()
-
+            if(e.button===0){
+                saveRange()
+            }
             // 在编辑器区域之内完成点击，取消鼠标滑动到编辑区外面的事件
             $textElem.off('mouseleave', saveRange)
         })


### PR DESCRIPTION
## 遇到了什么问题

https://github.com/wangeditor-team/wangEditor/issues/2903#issue-800278313
在编辑区域内拖蓝一段文字后右键，拖蓝状态会被取消掉

原因是缺少对e.button 的判断，点击鼠标右键再松开这个动作也触发了 mouseup 回调中的 handler，并触发了 saveRange，继而触发restoreSelection -> removeAllRanges 。（我并不确定会不会对其它部分造成影响 review~

## 你的预期是什么

在编辑区域内拖蓝一段文字后右键，拖蓝状态不会被取消掉

## 是否进行了详细的自测？

*是*

