### PR TITLE
fix: 修复右键取消选区bug

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -261,7 +261,7 @@ class Text {
             $textElem.on('mouseleave', saveRange)
         })
 
-        $textElem.on('mouseup', () => {
+        $textElem.on('mouseup', (e: MouseEvent) => {
             const selection = editor.selection
             const range = selection.getRange()
 
@@ -270,7 +270,7 @@ class Text {
             const { startOffset, endOffset } = range
             let endContainer: Node | undefined = range?.endContainer
             // 修复当selection结束时，点击编辑器内部，保存选区异常的情况
-            if (startOffset !== endOffset && endContainer != null) {
+            if (startOffset !== endOffset && endContainer != null && e.button === 0) {
                 range?.setStart(endContainer, endOffset)
             }
 


### PR DESCRIPTION
## 遇到了什么问题
*[#2903](https://github.com/wangeditor-team/wangEditor/issues/2903)*
## 你的预期是什么
*右键不会导致选区取消*
## 是否进行了详细的自测？
*是*