### PR TITLE
fix: 菜单分离后禁止编辑器内容不显示

### DIFF
--- a/src/assets/style/disable.less
+++ b/src/assets/style/disable.less
@@ -1,7 +1,4 @@
 .w-e-content-mantle{
-    position: absolute;
-    top: 0;
-    left: 0;
     width: 100%;
     height: 100%;
     overflow-y: auto;

--- a/src/assets/style/text.less
+++ b/src/assets/style/text.less
@@ -1,5 +1,6 @@
 .w-e-text-container {
     position: relative;
+    height: 100%;
 
     .w-e-progress {
         position: absolute;


### PR DESCRIPTION
 设置编辑器分离后不显示内容的原因跟逻辑代码没有关系， 就是样式上的问题，

此外当编辑区域与菜单分离的时候， 编辑区域聚焦有问题 就给  .w-e-text-container 样式加了高度100%