### PR TITLE
fix: 将hover引起droplist菜单显示改为click

### DIFF
--- a/cypress/integration/e2e/menus/align.spec.ts
+++ b/cypress/integration/e2e/menus/align.spec.ts
@@ -18,7 +18,7 @@ describe('对齐方式', () => {
 
         cy.get('@Editable').find('p').should('not.have.css', 'text-align', 'center')
 
-        cy.getByClass('toolbar').children().eq(pos).trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).trigger('click')
         cy.wait(200)
 
         cy.getByClass('toolbar')
@@ -49,7 +49,7 @@ describe('对齐方式', () => {
 
         cy.get('@Editable').find('p').should('not.have.css', 'text-align', 'left')
 
-        cy.getByClass('toolbar').children().eq(pos).trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).trigger('click')
         cy.wait(200)
 
         cy.getByClass('toolbar')
@@ -78,7 +78,7 @@ describe('对齐方式', () => {
             .contains('居中')
             .click()
 
-        cy.getByClass('toolbar').children().eq(pos).trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).trigger('click')
         cy.wait(200)
 
         cy.get('@droplist').find('.w-e-list').children().eq(0).click()
@@ -92,7 +92,7 @@ describe('对齐方式', () => {
 
         cy.get('@Editable').find('p').should('not.have.css', 'text-align', 'right')
 
-        cy.getByClass('toolbar').children().eq(pos).trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).trigger('click')
         cy.wait(200)
 
         cy.getByClass('toolbar')
@@ -123,7 +123,7 @@ describe('对齐方式', () => {
 
         cy.get('@Editable').find('p').should('not.have.css', 'text-align', 'justify')
 
-        cy.getByClass('toolbar').children().eq(pos).trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).trigger('click')
         cy.wait(200)
 
         cy.getByClass('toolbar')

--- a/cypress/integration/e2e/menus/bg.spec.ts
+++ b/cypress/integration/e2e/menus/bg.spec.ts
@@ -28,7 +28,7 @@ describe('背景颜色', () => {
     const dropItemIndex = 2
 
     it('点击菜单能打开设置文字背景颜色的下拉', () => {
-        cy.getByClass('toolbar').children().eq(menuIndex).as('bgColor').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(menuIndex).as('bgColor').trigger('click')
 
         cy.wait(200)
 
@@ -54,7 +54,7 @@ describe('背景颜色', () => {
 
         cy.saveRange()
 
-        cy.getByClass('toolbar').children().eq(menuIndex).as('bgColor').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(menuIndex).as('bgColor').trigger('click')
 
         cy.wait(200)
 

--- a/cypress/integration/e2e/menus/fontColor.spec.ts
+++ b/cypress/integration/e2e/menus/fontColor.spec.ts
@@ -17,7 +17,7 @@ describe('文字颜色', () => {
     const dropItemIndex = 2
 
     it('点击菜单能打开设置文字颜色的下拉', () => {
-        cy.getByClass('toolbar').children().eq(menuIndex).as('textColor').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(menuIndex).as('textColor').trigger('click')
 
         cy.wait(200)
 
@@ -43,7 +43,7 @@ describe('文字颜色', () => {
 
         cy.saveRange()
 
-        cy.getByClass('toolbar').children().eq(menuIndex).as('textColor').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(menuIndex).as('textColor').trigger('click')
 
         cy.wait(200)
 

--- a/cypress/integration/e2e/menus/fontFamily.spec.ts
+++ b/cypress/integration/e2e/menus/fontFamily.spec.ts
@@ -16,7 +16,7 @@ describe('字体', () => {
     const dropItemIndex = 6
 
     it('点击菜单能打开设置文体的下拉菜单', () => {
-        cy.getByClass('toolbar').children().eq(menuIndex).as('fontFamily').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(menuIndex).as('fontFamily').trigger('click')
 
         cy.wait(200)
 
@@ -42,7 +42,7 @@ describe('字体', () => {
 
         cy.saveRange()
 
-        cy.getByClass('toolbar').children().eq(menuIndex).as('fontFamily').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(menuIndex).as('fontFamily').trigger('click')
 
         cy.wait(200)
 

--- a/cypress/integration/e2e/menus/fontSize.spec.ts
+++ b/cypress/integration/e2e/menus/fontSize.spec.ts
@@ -15,7 +15,7 @@ describe('设置文字大小', () => {
     const dropItemIndex = 6
 
     it('点击菜单能打开设置文字大小的下拉菜单', () => {
-        cy.getByClass('toolbar').children().eq(menuIndex).as('fontSize').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(menuIndex).as('fontSize').trigger('click')
 
         cy.wait(200)
 
@@ -41,7 +41,7 @@ describe('设置文字大小', () => {
 
         cy.saveRange()
 
-        cy.getByClass('toolbar').children().eq(menuIndex).as('fontSize').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(menuIndex).as('fontSize').trigger('click')
 
         cy.wait(200)
 

--- a/cypress/integration/e2e/menus/indent.spec.ts
+++ b/cypress/integration/e2e/menus/indent.spec.ts
@@ -15,7 +15,7 @@ describe('缩进', () => {
     const text = '这是一段文本'
 
     it('可以点击菜单打开设置缩进的下拉菜单', () => {
-        cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('click')
         cy.wait(200)
 
         cy.get('@indentMenu').find('.w-e-droplist').as('droplist').should('be.visible')
@@ -29,7 +29,7 @@ describe('缩进', () => {
     it('可以给选中的文本添加对应的缩进样式，并且多次点击会叠加indent样式', () => {
         cy.get('@Editable').type(text)
 
-        cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('click')
         cy.wait(200)
 
         cy.get('@indentMenu')
@@ -53,7 +53,7 @@ describe('缩进', () => {
                         expect($p.get(0).style.paddingLeft).to.eq(`${clickCount * basePadding}em`)
                     })
 
-                cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('mouseenter')
+                cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('click')
                 cy.wait(200)
 
                 cy.get('@addIndentBtn')
@@ -75,7 +75,7 @@ describe('缩进', () => {
     it('可以给选中的文本减少对应的缩进样式', () => {
         cy.get('@Editable').type(text)
 
-        cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('click')
         cy.wait(200)
 
         cy.get('@indentMenu')
@@ -105,7 +105,7 @@ describe('缩进', () => {
                         expect($p.get(0).style.paddingLeft).to.eq(`${clickCount * basePadding}em`)
                     })
 
-                cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('mouseenter')
+                cy.getByClass('toolbar').children().eq(pos).as('indentMenu').trigger('click')
                 cy.wait(200)
 
                 cy.get('@decreaseIndentBtn')

--- a/cypress/integration/e2e/menus/lineHeight.spec.ts
+++ b/cypress/integration/e2e/menus/lineHeight.spec.ts
@@ -16,7 +16,7 @@ describe('行高', () => {
         '这是一段很长很长很长很长很长很长很长很长的文本这是一段很长很长很长很长很长很长很长很长的文本这是一段很长很长很长很长很长很长很长很长的文本这是一段很长很长很长很长很长很长很长很长的文本这是一段很长很长很长很长很长很长很长很长的文本这是一段很长很长很长很长很长很长很长很长的文本这是一段很长很长很长很长很长'
 
     it('可以点击菜单打开设置行高的下拉菜单', () => {
-        cy.getByClass('toolbar').children().eq(pos).as('lineHeightMenu').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).as('lineHeightMenu').trigger('click')
         cy.wait(200)
 
         cy.get('@lineHeightMenu').find('.w-e-droplist').as('droplist').should('be.visible')
@@ -30,7 +30,7 @@ describe('行高', () => {
     it('可以选择指定的行高项给选中的文本添加对应的行高样式', () => {
         cy.get('@Editable').type(text)
 
-        cy.getByClass('toolbar').children().eq(pos).as('lineHeightMenu').trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).as('lineHeightMenu').trigger('click')
         cy.wait(200)
 
         cy.get('@lineHeightMenu')

--- a/cypress/integration/e2e/menus/list.spec.ts
+++ b/cypress/integration/e2e/menus/list.spec.ts
@@ -16,7 +16,7 @@ describe('插入序列', () => {
     it('可以插入无序列表', () => {
         cy.get('@Editable').type(text1)
 
-        cy.getByClass('toolbar').children().eq(pos).trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).trigger('click')
 
         cy.wait(200)
 
@@ -53,7 +53,7 @@ describe('插入序列', () => {
     it('可以插入有序列表', () => {
         cy.get('@Editable').type(text1)
 
-        cy.getByClass('toolbar').children().eq(pos).trigger('mouseenter')
+        cy.getByClass('toolbar').children().eq(pos).trigger('click')
 
         cy.wait(200)
 

--- a/src/menus/menu-constructors/DropList.ts
+++ b/src/menus/menu-constructors/DropList.ts
@@ -28,11 +28,9 @@ class DropList {
     private _show: boolean
 
     public hideTimeoutId: number
-    public showTimeoutId: number
 
     constructor(menu: DropListMenu, conf: DropListConf) {
         this.hideTimeoutId = 0
-        this.showTimeoutId = 0
         this.menu = menu
         this.conf = conf
 
@@ -60,8 +58,11 @@ class DropList {
             if ($elem) {
                 $li.append($elem)
                 $list.append($li)
-                $li.on('click', () => {
+                $li.on('click', (e: Event) => {
                     clickHandler(value)
+
+                    // 阻止冒泡
+                    e.stopPropagation()
 
                     // item 点击之后，隐藏 list
                     this.hideTimeoutId = window.setTimeout(() => {
@@ -122,11 +123,6 @@ class DropList {
      * 隐藏 DropList
      */
     public hide() {
-        if (this.showTimeoutId) {
-            // 清除之前的定时显示
-            clearTimeout(this.showTimeoutId)
-        }
-
         const $container = this.$container
         if (!this._show) {
             return

--- a/src/menus/menu-constructors/DropListMenu.ts
+++ b/src/menus/menu-constructors/DropListMenu.ts
@@ -38,7 +38,7 @@ class DropListMenu extends Menu {
 
         // 绑定事件
         $elem
-            .on('mouseenter', () => {
+            .on('click', () => {
                 if (editor.selection.getRange() == null) {
                     return
                 }
@@ -46,9 +46,7 @@ class DropListMenu extends Menu {
                 // 触发 droplist 悬浮事件
                 editor.txt.eventHooks.dropListMenuHoverEvents.forEach(fn => fn())
                 // 显示
-                dropList.showTimeoutId = window.setTimeout(() => {
-                    dropList.show()
-                }, 200)
+                dropList.show()
             })
             .on('mouseleave', () => {
                 $elem.css('z-index', 'auto')

--- a/test/unit/menus/droplist-menu.test.ts
+++ b/test/unit/menus/droplist-menu.test.ts
@@ -42,10 +42,10 @@ describe('dropList menu', () => {
         expect(droplistMenu.dropList instanceof DropList).toBeTruthy()
     })
 
-    test('初始化基本的下拉菜单，模拟菜单mouseenter事件会展开下来菜单', done => {
+    test('初始化基本的下拉菜单，模拟菜单click事件会展开下来菜单', done => {
         expect.assertions(2)
 
-        dispatchEvent(menuEl, 'mouseenter', 'MouseEvent')
+        dispatchEvent(menuEl, 'click')
 
         setTimeout(() => {
             expect(droplistMenu.dropList.isShow).toBeTruthy()
@@ -57,7 +57,7 @@ describe('dropList menu', () => {
     test('初始化基本的下拉菜单，模拟菜单mouseleave事件会隐藏菜单', done => {
         expect.assertions(3)
 
-        dispatchEvent(menuEl, 'mouseenter', 'MouseEvent')
+        dispatchEvent(menuEl, 'click')
 
         setTimeout(() => {
             expect(droplistMenu.dropList.isShow).toBeTruthy()
@@ -72,11 +72,11 @@ describe('dropList menu', () => {
         }, 300)
     })
 
-    test('初始化基本的下拉菜单，模拟菜单mouseenter事件如果编辑器当前的range为空，则直接返回', () => {
+    test('初始化基本的下拉菜单，模拟菜单click事件如果编辑器当前的range为空，则直接返回', () => {
         const mockGetRage = jest.spyOn(editor.selection, 'getRange')
         mockGetRage.mockImplementation(() => null)
 
-        dispatchEvent(menuEl, 'mouseenter', 'MouseEvent')
+        dispatchEvent(menuEl, 'click')
 
         expect(droplistMenu.dropList.isShow).toBeFalsy()
     })


### PR DESCRIPTION
1. 将mouseenter事件引起droplist菜单显示改为click事件
2. 将jest与cypress模拟mouseenter事件同步为click事件