### PR TITLE
fix: 在ie编辑器外部mouseup,选区保存错误

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -264,6 +264,7 @@ class Text {
     private _saveRange(): void {
         const editor = this.editor
         const $textElem = editor.$textElem
+        const $document = $(document)
 
         // 保存当前的选区
         function saveRange() {
@@ -283,28 +284,25 @@ class Text {
         }
         $textElem.on('click', onceClickSaveRange)
 
+        function handleMouseUp() {
+            // 在编辑器区域之内完成点击，取消鼠标滑动到编辑区外面的事件
+            $textElem.off('mouseleave', saveRange)
+
+            $document.off('mouseup', handleMouseUp)
+        }
         $textElem.on('mousedown', () => {
             // mousedown 状态下，鼠标滑动到编辑区域外面，也需要保存选区
             $textElem.on('mouseleave', saveRange)
+            $document.on('mouseup', handleMouseUp)
         })
 
         $textElem.on('mouseup', (e: MouseEvent) => {
             const selection = editor.selection
             const range = selection.getRange()
 
-            if (range == null) return
-
-            const { startOffset, endOffset } = range
-            let endContainer: Node | undefined = range?.endContainer
-            // 修复当selection结束时，点击编辑器内部，保存选区异常的情况
-            if (startOffset !== endOffset && endContainer != null && e.button === 0) {
-                range?.setStart(endContainer, endOffset)
-            }
+            if (range === null) return
 
             saveRange()
-
-            // 在编辑器区域之内完成点击，取消鼠标滑动到编辑区外面的事件
-            $textElem.off('mouseleave', saveRange)
         })
     }
 


### PR DESCRIPTION
ie上，在编辑器范围内mousedown，然后在编辑器外mouseup，依然会触发编辑器的mouseup事件。
鼠标移到编辑器外部，触发了mouseleave，保存了选区（有选中内容）。然后松开鼠标，触发了编辑器mouseup（ie上才会），保存选区，走进了原来mouseup中的if，选区被改成没有选中内容。导致加粗、设置字体大小之类的失败