### PR TITLE
fix: 兼容火狐浏览器video标签存在时光标无法输入问题

### DIFF
--- a/examples/upload-video.html
+++ b/examples/upload-video.html
@@ -15,7 +15,7 @@
     <div id="div1">
         <p>欢迎使用 <b>wangEditor</b> 富文本编辑器</p>
         <p>测试视频</p>
-        <p>
+        <p data-we-video-p="true">
             <video src="/server/upload-files/测试1-w9b.mp4" controls="controls" style="max-width:100%"></video>
         </p>
     </div>

--- a/src/menus/video/bind-event/index.ts
+++ b/src/menus/video/bind-event/index.ts
@@ -5,6 +5,7 @@
 
 import Editor from '../../../editor/index'
 import bindTooltipVideo from './tooltip-event'
+import bindEventKeyboardEvent from './keyboard'
 
 /**
  * 绑定事件
@@ -13,6 +14,7 @@ import bindTooltipVideo from './tooltip-event'
 function bindEvent(editor: Editor): void {
     //Tooltip
     bindTooltipVideo(editor)
+    bindEventKeyboardEvent(editor)
 }
 
 export default bindEvent

--- a/src/menus/video/bind-event/keyboard.ts
+++ b/src/menus/video/bind-event/keyboard.ts
@@ -1,0 +1,35 @@
+/**
+ * @description 兼容火狐浏览器内核有video标签时光标定位不对问题
+ * @author yanbiao(86driver)
+ */
+import Editor from '../../../editor/index'
+import { UA } from '../../../utils/util'
+
+export default function bindEventKeyboardEvent(editor: Editor) {
+    if (!UA.isFirefox) return
+    const { txt, selection } = editor
+    const { keydownEvents } = txt.eventHooks
+
+    keydownEvents.push(function (e) {
+        // 实时保存选区
+        // editor.selection.saveRange()
+        const $selectionContainerElem = selection.getSelectionContainerElem()
+        if ($selectionContainerElem) {
+            const $topElem = $selectionContainerElem.getNodeTop(editor)
+            const $preElem = $topElem.length
+                ? $topElem.prev().length
+                    ? $topElem.prev()
+                    : null
+                : null
+            if ($preElem && $preElem.attr('data-we-video-p')) {
+                // 光标处于选区开头
+                if (selection.getCursorPos() === 0) {
+                    // 如果上一个dom是包含video， 按下删除连video一块删除
+                    if (e.keyCode === 8) {
+                        $preElem.remove()
+                    }
+                }
+            }
+        }
+    })
+}

--- a/src/menus/video/upload-video.ts
+++ b/src/menus/video/upload-video.ts
@@ -8,6 +8,7 @@ import { arrForEach, forEach } from '../../utils/util'
 import post from '../../editor/upload/upload-core'
 import Progress from '../../editor/upload/progress'
 import { EMPTY_P } from '../../utils/const'
+import { UA } from '../../utils/util'
 
 type ResData = {
     url: string
@@ -250,10 +251,17 @@ class UploadVideo {
 
         // 判断用户是否自定义插入视频
         if (!config.customInsertVideo) {
-            editor.cmd.do(
-                'insertHTML',
-                `<video src="${url}" controls="controls" style="max-width:100%"></video>${EMPTY_P}`
-            )
+            if (UA.isFirefox) {
+                editor.cmd.do(
+                    'insertHTML',
+                    `<p data-we-video-p="true"><video src="${url}" controls="controls" style="max-width:100%"></video></p><p>&#8203</p>`
+                )
+            } else {
+                editor.cmd.do(
+                    'insertHTML',
+                    `<video src="${url}" controls="controls" style="max-width:100%"></video>${EMPTY_P}`
+                )
+            }
         } else {
             config.customInsertVideo(url)
             return

--- a/test/unit/menus/video/upload-video.test.ts
+++ b/test/unit/menus/video/upload-video.test.ts
@@ -9,6 +9,7 @@ import mockXHR from '../../../helpers/mock-xhr'
 import Editor from '../../../../src/editor'
 import UploadVideo from '../../../../src/menus/video/upload-video'
 import { EMPTY_P } from '../../../../src/utils/const'
+import { UA } from '../../../../src//utils/util'
 
 let editor: Editor
 let id = 1
@@ -53,6 +54,8 @@ const createMockFilse = (fileList: any[] = deaultFiles) => {
 describe('upload video', () => {
     beforeEach(() => {
         editor = createEditor(document, `div${id++}`)
+        // 假装不在火狐浏览器下
+        UA.isFirefox = false
     })
 
     test('能够初始化基本的UploadVideo类', () => {
@@ -62,7 +65,7 @@ describe('upload video', () => {
         expect(uploadVideo.insertVideo instanceof Function).toBeTruthy()
     })
 
-    test('调用 insertVideo 可以网编辑器里插入视频', () => {
+    test('调用 insertVideo 可以往编辑器里插入视频', () => {
         const uploadVideo = new UploadVideo(editor)
 
         mockSupportCommand()


### PR DESCRIPTION
chrome和firefox对 video标签 行为不一致， 所以针对firefox做特别处理， 使firefox在行为上尽量看起来和chrome表现一只