### PR TITLE
fix: 修复设置isFocus为false的情况下，初始化完成后依旧触发blur事件的问题

### DIFF
--- a/examples/auto-focus.html
+++ b/examples/auto-focus.html
@@ -27,6 +27,12 @@
 
         editor.config.focus = false
 
+        editor.config.onfocus = function () {
+            console.log('触发focus事件')
+        }
+        editor.config.onblur = function () {
+            console.log('触发blur事件')
+        }
         editor.create()
     </script>
 </body>

--- a/src/editor/init-fns/bind-event.ts
+++ b/src/editor/init-fns/bind-event.ts
@@ -69,10 +69,12 @@ function _bindFocusAndBlur(editor: Editor): void {
             editor.isFocus = true
         }
     }
-    if (document.activeElement === editor.$textElem.elems[0]) {
+    // fix: 增加判断条件，防止当用户设置isFocus=false时，初始化完成后点击其他元素依旧会触发blur事件的问题
+    if (document.activeElement === editor.$textElem.elems[0] && editor.config.focus) {
         _focusHandler(editor)
         editor.isFocus = true
     }
+    // 绑定监听事件
     $(document).on('click', listener)
     // 全局事件在编辑器实例销毁的时候进行解绑
     editor.beforeDestroy(function () {


### PR DESCRIPTION
解决当用户设置isFocus为false的情况下，编辑器初始化完成后点击其他元素依旧会触发blur事件的问题