### PR TITLE
fix: 粘贴图片性能问题

### DIFF
--- a/src/menus/img/bind-event/paste-img.ts
+++ b/src/menus/img/bind-event/paste-img.ts
@@ -73,8 +73,25 @@ function pasteImgHandler(e: ClipboardEvent, editor: Editor): void {
  * @param pasteEvents 粘贴事件列表
  */
 function bindPasteImg(editor: Editor): void {
-    // 绑定 paste 事件
-    editor.txt.eventHooks.pasteEvents.push((e: ClipboardEvent) => {
+    /**
+     * 绑定 paste 事件
+     * 这里使用了unshift，以前是push
+     * 在以前的流程中，pasteImgHandler触发之前，会调用到window.getSelection().removeAllRanges()
+     * 会导致性能变差。在编辑器中粘贴，粘贴耗时多了100+ms，根本原因未知
+     * 最小复现demo，在div内粘贴图片就可以看到getData耗时异常得长
+     * <html>
+     *     <div id="a" contenteditable="true"></div>
+     *     <script>
+     *         const div = document.getElementById('a')
+     *         div.addEventListener('paste', (e) => {
+     *             window.getSelection().removeAllRanges()
+     *             e.clipboardData.getData('text/html')
+     *         })
+     *     </script>
+     * </html>
+     * 因此改成unshift，先触发pasteImgHandler就不会有性能问题
+     */
+    editor.txt.eventHooks.pasteEvents.unshift((e: ClipboardEvent) => {
         pasteImgHandler(e, editor)
     })
 }

--- a/src/text/event-hooks/paste-text-html.ts
+++ b/src/text/event-hooks/paste-text-html.ts
@@ -121,7 +121,7 @@ function pasteTextHtml(editor: Editor, pasteEvents: Function[]) {
                 pasteHtml = '' + (pasteTextHandle(pasteHtml) || '') // html
             }
             // 粘贴的html的是否是css的style样式
-            let isCssStyle: boolean = /[\.\#\@]?\w+[^{]+\{[^}]*\}/.test(pasteHtml) // eslint-disable-line
+            let isCssStyle: boolean = /[\.\#\@]?\w+[ ]+\{[^}]*\}/.test(pasteHtml) // eslint-disable-line
             // 经过处理后还是包含暴露的css样式则直接插入它的text
             if (isCssStyle && pasteFilterStyle) {
                 editor.cmd.do('insertHTML', `${formatHtml(pasteText)}`) // text


### PR DESCRIPTION
卡死原因是正则性能较差，修改正则即可。同时在粘贴过程中有另外的问题也会导致粘贴图片耗时较长，一并fix