### PR TITLE
feat: 修复了append 时意外清除空格的问题

### DIFF
--- a/src/menus/table/bind-event/event/getNode.ts
+++ b/src/menus/table/bind-event/event/getNode.ts
@@ -32,12 +32,12 @@ class getNode {
      */
     public getCurrentRowIndex($node: HTMLElement, $dom: HTMLElement): Number {
         let _index: number = 0
-        let $nodeChild = $node.childNodes[0]
+        let $nodeChild = $node.children[0]
         //粘贴的table 最后一个节点才是tbody
         if ($nodeChild.nodeName === 'COLGROUP') {
-            $nodeChild = $node.childNodes[$node.childNodes.length - 1]
+            $nodeChild = $node.children[$node.children.length - 1]
         }
-        $nodeChild.childNodes.forEach((item, index) => {
+        Array.from($nodeChild.children).forEach((item, index) => {
             item === $dom ? (_index = index) : ''
         })
         return _index
@@ -56,7 +56,7 @@ class getNode {
                 ? $node
                 : $($node).parentUntil('TD', $node)?.elems[0]
         let colDom = $(rowDom).parent()
-        colDom.elems[0].childNodes.forEach((item, index) => {
+        Array.from(colDom.elems[0].children).forEach((item, index) => {
             item === rowDom ? (_index = index) : ''
         })
         return _index

--- a/src/menus/table/bind-event/event/operating-event.ts
+++ b/src/menus/table/bind-event/event/operating-event.ts
@@ -9,12 +9,12 @@ function ProcessingRow($node: DomElement, _index: number): DomElement {
     //执行获取tbody节点
     let $dom = generateDomAction($node)
     //取出所有的行
-    let domArray: Node[] = Array.prototype.slice.apply($dom.childNodes)
+    let domArray: HTMLElement[] = Array.prototype.slice.apply($dom.children)
     //列的数量
-    const childNodesLenght = domArray[0].childNodes.length
+    const childrenLength = domArray[0].children.length
     //创建新tr
     let tr = document.createElement('tr')
-    for (let i = 0; i < childNodesLenght; i++) {
+    for (let i = 0; i < childrenLength; i++) {
         const td = document.createElement('td')
         tr.appendChild(td)
     }
@@ -34,17 +34,17 @@ function ProcessingCol($node: DomElement, _index: number): DomElement {
     //执行获取tbody节点
     let $dom = generateDomAction($node)
     //取出所有的行
-    let domArray: Node[] = Array.prototype.slice.apply($dom.childNodes)
+    let domArray: HTMLElement[] = Array.prototype.slice.apply($dom.children)
     //创建td
     for (let i = 0; i < domArray.length; i++) {
         let cArray: Node[] = []
         //取出所有的列
-        domArray[i].childNodes.forEach(item => {
+        Array.from(domArray[i].children).forEach(item => {
             cArray.push(item)
         })
         //移除行的旧的子节点
-        while (domArray[i].childNodes.length !== 0) {
-            domArray[i].removeChild(domArray[i].childNodes[0])
+        while (domArray[i].children.length !== 0) {
+            domArray[i].removeChild(domArray[i].children[0])
         }
         //列分th td
         let td =
@@ -72,7 +72,7 @@ function DeleteRow($node: DomElement, _index: number): DomElement {
     //执行获取tbody节点
     let $dom = generateDomAction($node)
     //取出所有的行
-    let domArray: Node[] = Array.prototype.slice.apply($dom.childNodes)
+    let domArray: HTMLElement[] = Array.prototype.slice.apply($dom.children)
     //删除行
     domArray.splice(_index, 1)
     //移除、新增节点事件
@@ -89,17 +89,17 @@ function DeleteCol($node: DomElement, _index: number): DomElement {
     //执行获取tbody节点
     let $dom = generateDomAction($node)
     //取出所有的行
-    let domArray: Node[] = Array.prototype.slice.apply($dom.childNodes)
+    let domArray: HTMLElement[] = Array.prototype.slice.apply($dom.children)
     //创建td
     for (let i = 0; i < domArray.length; i++) {
         let cArray: Node[] = []
         //取出所有的列
-        domArray[i].childNodes.forEach(item => {
+        Array.from(domArray[i].children).forEach(item => {
             cArray.push(item)
         })
         //移除行的旧的子节点
-        while (domArray[i].childNodes.length !== 0) {
-            domArray[i].removeChild(domArray[i].childNodes[0])
+        while (domArray[i].children.length !== 0) {
+            domArray[i].removeChild(domArray[i].children[0])
         }
         cArray.splice(_index, 1)
         //插入新的子节点
@@ -122,15 +122,15 @@ function setTheHeader($node: DomElement, _index: number, type: string): DomEleme
     //执行获取tbody节点
     let $dom = generateDomAction($node)
     //取出所有的行
-    let domArray: Node[] = Array.prototype.slice.apply($dom.childNodes)
+    let domArray: HTMLElement[] = Array.prototype.slice.apply($dom.children)
     //列的数量
-    const childNodesLenght = domArray[_index].childNodes
+    const childrenLength = domArray[_index].children
     //创建新tr
     let tr = document.createElement('tr')
-    for (let i = 0; i < childNodesLenght.length; i++) {
+    for (let i = 0; i < childrenLength.length; i++) {
         //替换td为th
         const th = document.createElement(type)
-        childNodesLenght[i].childNodes.forEach(item => {
+        Array.from(childrenLength[i].children).forEach(item => {
             th.appendChild(item)
         })
         tr.appendChild(th)
@@ -147,10 +147,10 @@ function setTheHeader($node: DomElement, _index: number, type: string): DomEleme
  * @param $dom tbody节点
  * @param domArray  所有的行
  */
-function removeAndInsertAction($dom: ChildNode, domArray: Node[]) {
+function removeAndInsertAction($dom: Element, domArray: Node[]) {
     //移除所有的旧的子节点
-    while ($dom.childNodes.length !== 0) {
-        $dom.removeChild($dom.childNodes[0])
+    while ($dom.children.length !== 0) {
+        $dom.removeChild($dom.children[0])
     }
     //插入新的子节点
     for (let i = 0; i < domArray.length; i++) {
@@ -163,10 +163,10 @@ function removeAndInsertAction($dom: ChildNode, domArray: Node[]) {
  * 粘贴的table 第一个节点是<colgroup> 最后的节点<tbody>
  * @param dom
  */
-function generateDomAction($node: DomElement): ChildNode {
-    let $dom: ChildNode = $node.elems[0].childNodes[0]
+function generateDomAction($node: DomElement) {
+    let $dom = $node.elems[0].children[0]
     if ($dom.nodeName === 'COLGROUP') {
-        $dom = $node.elems[0].childNodes[$node.elems[0].childNodes.length - 1]
+        $dom = $node.elems[0].children[$node.elems[0].children.length - 1]
     }
     return $dom
 }

--- a/src/menus/table/bind-event/tooltip-event.ts
+++ b/src/menus/table/bind-event/tooltip-event.ts
@@ -98,7 +98,7 @@ function createShowHideFn(editor: Editor) {
                     let htmlStr = getnode.getTableHtml($node.elems[0])
                     //获取新生成的table 判断是否是最后一行被删除 是 删除整个table
                     const trLength: number = operatingEvent.DeleteRow($(htmlStr), index).elems[0]
-                        .childNodes[0].childNodes.length
+                        .children[0].children.length
                     //生成新的table
                     let newdom: string = ''
                     // 选中table
@@ -162,7 +162,7 @@ function createShowHideFn(editor: Editor) {
                     let htmlStr = getnode.getTableHtml($node.elems[0])
                     //获取新生成的table 判断是否是最后一列被删除 是 删除整个table
                     const tdLength: number = operatingEvent.DeleteCol($(htmlStr), index).elems[0]
-                        .childNodes[0].childNodes[0].childNodes.length
+                        .children[0].children[0].children.length
                     //生成新的table
                     let newdom: string = ''
                     // 选中table
@@ -311,7 +311,7 @@ export default function bindTooltipEvent(editor: Editor) {
 function _isEmptyP($node: DomElement, newdom: string): string {
     // 当表格的下一个兄弟节点是空行时，在 newdom 后添加 EMPTY_P
     let nextNode = $node.elems[0].nextSibling as HTMLElement
-    if (nextNode.innerHTML === '<br>') {
+    if (!nextNode || nextNode.innerHTML === '<br>') {
         newdom += `${EMPTY_P}`
     }
     return newdom

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -186,7 +186,6 @@ class Text {
             // 内容用 p 标签包裹
             val = `<p>${val}</p>`
         }
-        val = val.replace(/\s+</g, '<')
         $textElem.html(val)
 
         // 初始化选区，将光标定位到内容尾部


### PR DESCRIPTION
解决了两个问题
1. 解决在 执行 ```editor.txt.append```, ```editor.txt.html``` 时意外清除已存在html空格 的问题
2. 解决了 编辑器中出现了带有空白换行符的table时, table的添加/删除 行列失败
(因为该issue 出现是之前为了修改另一个关于table issue出现, 所以修改后, 之前那个table 的issue
也需要再测试一下  https://github.com/wangeditor-team/wangEditor/issues/2872  )