### PR TITLE
fix: 修复鼠标选中文字之后，再选择文字中间位置插入图片导致选中文字消失的问题

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -304,13 +304,13 @@ class Text {
         $textElem.on('mouseup', (e: MouseEvent) => {
             // 记得移除$textElem的mouseleave事件, 避免内存泄露
             $textElem.off('mouseleave', listenMouseLeave)
-
-            const selection = editor.selection
-            const range = selection.getRange()
-
-            if (range === null) return
-
-            saveRange()
+            // fix：避免当选中一段文字之后，再次点击文字中间位置无法更新selection问题。issue#3096
+            setTimeout(() => {
+                const selection = editor.selection
+                const range = selection.getRange()
+                if (range === null) return
+                saveRange()
+            }, 0)
         })
     }
 

--- a/test/unit/text/index.test.ts
+++ b/test/unit/text/index.test.ts
@@ -138,7 +138,7 @@ describe('Editor Text test', () => {
         expect(saveRangeFn).not.toBeCalled()
     })
 
-    test('编辑器初始化后，编辑器区域会绑定 mouseup mousedown 事件，对存在的range进行处理', () => {
+    test('编辑器初始化后，编辑器区域会绑定 mouseup mousedown 事件，对存在的range进行处理', (done: jest.DoneCallback) => {
         const saveRangeFn = jest.fn()
 
         const getRangeFn = jest.fn(() => ({
@@ -155,7 +155,10 @@ describe('Editor Text test', () => {
         dispatchEvent(editor.$textElem, 'mousedown', 'MouseEvent')
         dispatchEvent(editor.$textElem, 'mouseup', 'MouseEvent')
 
-        expect(saveRangeFn).toBeCalled()
+        setTimeout(() => {
+            expect(saveRangeFn).toBeCalled()
+            done()
+        }, 0)
     })
 
     test('编辑器初始化后，编辑器区域会绑定 click 事件，触发执行eventsHook clickEvent的函数执行', () => {


### PR DESCRIPTION
修复鼠标选中文字之后，再选择文字中间位置插入图片导致选中文字消失的问题
这个问题不止是插入图片的时候会发生，选中之后再选择文字中间热任何位置去插入表情和图片都会造成，选中文字丢失的情况。
定位到的原因是因为第二次点击时的selection区域没有被获取到