### PR TITLE
fix: placeholder文本中存在`.`不显示

### DIFF
--- a/src/editor/init-fns/i18next-init.ts
+++ b/src/editor/init-fns/i18next-init.ts
@@ -27,8 +27,14 @@ function i18nextInit(editor: Editor) {
 
     // 没有引入 i18next 的替代品
     editor.i18next = {
-        t(str: string) {
+        t(str: string, isPlaceholderText: boolean = false) {
+            // 若是placeholder文本，无需split #3172
+            if (isPlaceholderText) {
+                return str
+            }
+
             const strArr = str.split('.')
+
             return strArr[strArr.length - 1]
         },
     }

--- a/src/editor/init-fns/init-dom.ts
+++ b/src/editor/init-fns/init-dom.ts
@@ -60,7 +60,8 @@ export default function (editor: Editor): void {
     $textElem.attr('contenteditable', 'true').css('width', '100%').css('height', '100%')
 
     // 添加 placeholder
-    const $placeholder = $(`<div>${i18next.t(editor.config.placeholder)}</div>`)
+    const $placeholder = $(`<div>${i18next.t(editor.config.placeholder, true)}</div>`)
+
     $placeholder.addClass('placeholder')
 
     // 初始化编辑区域内容


### PR DESCRIPTION
## 遇到了什么问题

#3172
placeholder末尾添加`.`，造成placeholder不显示

## 你的预期是什么

placeholder文本可以添加`.`且正常显示

## 是否进行了详细的自测？

是