### PR TITLE
fix: 修复默认todo没有触发change的问题

### DIFF
--- a/examples/todo.html
+++ b/examples/todo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>wangEditor example</title>
+</head>
+
+<body>
+    <p>
+        wangEditor demo
+    </p>
+
+    <div id="div1">
+        <ul class="w-e-todo">
+            <li><span contenteditable="false"><input type="checkbox"/></span>写代码</li>
+        </ul>
+        <ul class="w-e-todo">
+            <li><span contenteditable="false"><input type="checkbox"/></span>睡觉</li>
+        </ul>
+        <ul class="w-e-todo">
+            <li><span contenteditable="false"><input type="checkbox"/></span>打豆豆</li>
+        </ul>
+    </div>
+
+    <script src="../dist/wangEditor.js"></script>
+    <script>
+        // 改为使用var声明，才能在window对象上获取到编辑器实例，方便e2e测试
+        var E = window.wangEditor
+        var editor = new E('#div1')
+
+        editor.config.onchange = function (newHtml) {
+            console.log('onchange', newHtml)
+        }
+        editor.config.onblur = function (newHtml) {
+            console.log('onblur', newHtml)
+        }
+
+        editor.create()
+    </script>
+</body>
+
+</html>

--- a/src/menus/todo/bind-event/index.ts
+++ b/src/menus/todo/bind-event/index.ts
@@ -145,9 +145,27 @@ function bindEvent(editor: Editor) {
             }
         }
     }
+
+    /**
+     * input 的点击事件（ input 默认不会产生 attribute 的改变 ）
+     * @param e 事件属性
+     */
+    function inputClick(e?: Event): void {
+        if (e && e.target instanceof HTMLInputElement) {
+            if (e.target.type === 'checkbox') {
+                if (e.target.checked) {
+                    e.target.setAttribute('checked', 'true')
+                } else {
+                    e.target.removeAttribute('checked')
+                }
+            }
+        }
+    }
+
     editor.txt.eventHooks.enterDownEvents.push(todoEnter)
     editor.txt.eventHooks.deleteUpEvents.push(deleteUp)
     editor.txt.eventHooks.deleteDownEvents.push(delDown)
+    editor.txt.eventHooks.clickEvents.push(inputClick)
 }
 
 export default bindEvent

--- a/src/menus/todo/todo.ts
+++ b/src/menus/todo/todo.ts
@@ -12,22 +12,12 @@ export class todo {
     }
 
     public init() {
-        const $input = this.getInput()
         const $child = this.$child
         const $inputContainer = this.getInputContainer()
 
         if ($child) {
             $child.insertAfter($inputContainer)
         }
-
-        $input.on('click', () => {
-            if (this.checked) {
-                $input?.removeAttr('checked')
-            } else {
-                $input?.attr('checked', '')
-            }
-            this.checked = !this.checked
-        })
     }
 
     public getInput(): DomElement {


### PR DESCRIPTION
出现bug原因是input默认没有style上的更新，dom中attribute没有变化，致使change没有监听到。
解决：在初始化时，给input绑定事件，以达到点击时attribute更新的效果，从而触发change。