### PR TITLE
fix: 修复全选删除文本无法删除干净的问题

### DIFF
--- a/src/text/event-hooks/del-to-keep-p.ts
+++ b/src/text/event-hooks/del-to-keep-p.ts
@@ -16,14 +16,14 @@ import $ from '../../utils/dom-core'
 function deleteToKeepP(editor: Editor, deleteUpEvents: Function[], deleteDownEvents: Function[]) {
     function upFn() {
         const $textElem = editor.$textElem
-        const txtHtml = $textElem.html().toLowerCase().trim()
 
-        // firefox 时用 txtHtml === '<br>' 判断，其他用 !txtHtml 判断
-        if (!txtHtml || txtHtml === '<br>') {
+        // 编辑器中的字符是""或空白，说明内容为空
+        if (/^\s*$/.test(editor.$textElem.text())) {
             // 内容空了
             const $p = $(EMPTY_P)
             $textElem.html(' ') // 一定要先清空，否则在 firefox 下有问题
             $textElem.append($p)
+
             editor.selection.createRangeByElem($p, false, true)
             editor.selection.restoreSelection()
             // 设置折叠后的光标位置，在firebox等浏览器下

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -348,14 +348,14 @@ class Text {
 
         // delete 键 up 时 hooks
         $textElem.on('keyup', (e: KeyboardEvent) => {
-            if (e.keyCode !== 8) return
+            if (e.keyCode !== 8 && e.keyCode !== 46) return
             const deleteUpEvents = eventHooks.deleteUpEvents
             deleteUpEvents.forEach(fn => fn(e))
         })
 
         // delete 键 down 时 hooks
         $textElem.on('keydown', (e: KeyboardEvent) => {
-            if (e.keyCode !== 8) return
+            if (e.keyCode !== 8 && e.keyCode !== 46) return
             const deleteDownEvents = eventHooks.deleteDownEvents
             deleteDownEvents.forEach(fn => fn(e))
         })

--- a/test/unit/text/del-to-keep-p.test.ts
+++ b/test/unit/text/del-to-keep-p.test.ts
@@ -31,7 +31,7 @@ describe('editor.text event-hooks tab-to-space test', () => {
             fn()
         })
 
-        expect(editor.$textElem.html()).toEqual(EMPTY_P)
+        expect(editor.$textElem.html()).toEqual(` ${EMPTY_P}`)
     })
 
     test('当编辑器内容只有 <br> 时，执行 up 函数，则会插入 EMPTY_P 内容', () => {


### PR DESCRIPTION
解决方法：

- 更改判断编辑器内容是否为空的条件

- 增加delete按键的监听