### PR TITLE
fix:修复初始化菜单时,菜单未按配置顺序排列的问题

### DIFF
--- a/src/menus/index.ts
+++ b/src/menus/index.ts
@@ -48,15 +48,14 @@ class Menus {
         })
 
         config.menus.forEach(menuKey => {
-            const MenuConstructor = this.constructorList[menuKey] // 暂用 any ，后面再替换
-            this._initMenuList(menuKey, MenuConstructor)
+            if(Object.keys(Editor.globalCustomMenuConstructorList).includes(menuKey)){//自定义工具列表
+                const MenuConstructor = Editor.globalCustomMenuConstructorList[menuKey] // 暂用 any ，后面再替换
+                this._initMenuList(menuKey, MenuConstructor)
+            }else if(!excludeMenus.includes(menuKey)){
+                const MenuConstructor = this.constructorList[menuKey] // 暂用 any ，后面再替换
+                this._initMenuList(menuKey, MenuConstructor)
+            }
         })
-
-        // 全局注册
-        for (let [menuKey, menuFun] of Object.entries(Editor.globalCustomMenuConstructorList)) {
-            const MenuConstructor = menuFun // 暂用 any ，后面再替换
-            this._initMenuList(menuKey, MenuConstructor)
-        }
 
         // 渲染 DOM
         this._addToToolbar()


### PR DESCRIPTION
## 遇到了什么问题

   *原有代码如果设置了自定义的菜单，菜单顺序目前不能按设置顺序展示*

## 你的预期是什么

  预期：菜单能按开发者设置的顺序进行排序

自测结果：*修改之后，符合预期，能按开发者设置的顺序进行排序*

## 是否进行了详细的自测？
 是
