### PR TITLE
fix: 修复禁用状态下scroll-to-head功能失效

### DIFF
--- a/src/editor/disable/index.ts
+++ b/src/editor/disable/index.ts
@@ -37,6 +37,7 @@ export default function disableInit(editor: Editor) {
         $menuDom = $(`<div class="w-e-menue-mantle" style="z-index:${menuZindexValue}"></div>`)
         editor.$toolbarElem.append($menuDom)
         isCurtain = true
+        editor.isEnable = false
     }
 
     // 销毁幕布并显示可编辑区域
@@ -46,6 +47,7 @@ export default function disableInit(editor: Editor) {
         $menuDom.remove()
         editor.$textElem.show()
         isCurtain = false
+        editor.isEnable = true
     }
 
     return { disable, enable }

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -65,6 +65,7 @@ class Editor {
     public zIndex: ZIndex
     public change: Change
     public history: History
+    public isEnable: Boolean
 
     // 实例销毁前需要执行的钩子集合
     private beforeDestroyHooks: Function[] = []
@@ -112,6 +113,7 @@ class Editor {
         const { disable, enable } = disableInit(this)
         this.disable = disable
         this.enable = enable
+        this.isEnable = true
     }
 
     /**

--- a/src/editor/init-fns/scroll-to-head.ts
+++ b/src/editor/init-fns/scroll-to-head.ts
@@ -11,7 +11,9 @@ import Editor from '../index'
  * @param id 标题锚点id
  */
 const scrollToHead = (editor: Editor, id: string) => {
-    const $textElem = editor.$textElem
+    const $textElem = editor.isEnable
+        ? editor.$textElem
+        : editor.$textContainerElem.find('.w-e-content-mantle')
     const $targetHead = $textElem.find(`[id='${id}']`)
     const targetTop = $targetHead.getOffsetData().top
     $textElem.scrollTop(targetTop)

--- a/test/unit/editor/disable.test.ts
+++ b/test/unit/editor/disable.test.ts
@@ -44,8 +44,10 @@ describe('Editor disable', () => {
         disabledObj.disable()
 
         expect(editor.$textElem.elems[0].style.display).toBe('none')
+        expect(editor.isEnable).toBe(false)
 
         disabledObj.enable()
+        expect(editor.isEnable).toBe(true)
 
         expect(editor.$textElem.elems[0].style.display).toBe('block')
     })


### PR DESCRIPTION
由于使用状态和禁用状态下操作的是两个dom， 所以会导致scrollToHead功能失效。

发现现在编辑器并没有暴露出编辑器是否禁用状态，考虑到之后可能还会用到是否禁用这个状态， 所以在 editor/index.ts下增加isEnable属性来获取编辑器是否已被禁用, 并在执行{disable, enable} 方法中同步更新该状态