### PR TITLE
fix: 修复panel菜单position位置的问题

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -41,6 +41,11 @@
         //     '微软雅黑',
         // ]
 
+        // 这行代码用来测试不同屏幕宽度，panel菜单的位置
+        // editor.config.menus = [
+        //     'image'
+        // ] 
+
         editor.config.showFullScreen = true
         editor.create()
     </script>

--- a/src/menus/menu-constructors/Panel.ts
+++ b/src/menus/menu-constructors/Panel.ts
@@ -62,7 +62,18 @@ class Panel {
         const rect = menu.editor.$toolbarElem.getBoundingClientRect()
         const menuRect = menu.$elem.getBoundingClientRect()
         const top = rect.height + rect.top - menuRect.top
-        const left = (rect.width - width) / 2 + rect.left - menuRect.left
+        let left = (rect.width - width) / 2 + rect.left - menuRect.left
+        const offset = 300 // icon与panel菜单距离偏移量暂定 300
+        if (Math.abs(left) > offset) {
+            // panel菜单离工具栏icon过远时，让panel菜单出现在icon正下方，处理边界逻辑
+            if (menuRect.left < document.documentElement.clientWidth / 2) {
+                // icon在左侧
+                left = -menuRect.width / 2
+            } else {
+                // icon在右侧
+                left = -width + menuRect.width / 2
+            }
+        }
 
         $container
             .css('width', width + 'px')


### PR DESCRIPTION
* 设置默认offset，当偏移量过大，将菜单设置在toolbar icon下方
* 考虑左右边界位置
* 最终目的 - 修复panel菜单position位置的问题