### PR TITLE
fix: 修复行内code回车后元素替换不正确的问题

### DIFF
--- a/src/text/event-hooks/enter-to-create-p.ts
+++ b/src/text/event-hooks/enter-to-create-p.ts
@@ -36,7 +36,7 @@ function enterToCreateP(editor: Editor, enterUpEvents: Function[], enterDownEven
         if ($parentElem.html() === '<code><br></code>') {
             // 回车之前光标所在一个 <p><code>.....</code></p> ，忽然回车生成一个空的 <p><code><br></code></p>
             // 而且继续回车跳不出去，因此只能特殊处理
-            insertEmptyP($selectionElem)
+            insertEmptyP($selectionElem.parent())
             return
         }
 


### PR DESCRIPTION
## 遇到了什么问题
bug描述见：#3285  

bug原因为行内code键入回车后，会将生成的空的`<p><code><br></code></p>` 中的 `<code><br></code>` 片段替换为 `<p><br></p>` ，并且导致了当前光标位置在编辑器内的定位位置不正确，后续插入新的代码块时便会出错。

正确的代码应该将`<p><code><br></code></p>`整个替换为`<p><br></p>` 。


## 你的预期是什么
行内code键入回车后，将生成的空的`<p><code><br></code></p>`整个替换为`<p><br></p>`。保证后续插入新代码片段及其他内容样式能够正确显示


## 是否进行了详细的自测？

是 