### PR TITLE
绑定与Ctrl+Z的对应的快捷键Ctrl+Y到 恢复动作

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -391,7 +391,23 @@ class Text {
                 }
             }
         })
-
+        
+        //恢复 快捷键 Ctrl+y
+        $textElem.on('keydown', (e: KeyboardEvent) => {
+            if (
+                // 编辑器处于聚焦状态下（多编辑器实例） || 当前处于兼容模式（兼容模式撤销/恢复后不聚焦，所以直接过，但会造成多编辑器同时撤销/恢复）
+                (editor.isFocus || editor.isCompatibleMode) &&
+                (e.ctrlKey || e.metaKey) &&
+                e.keyCode === 89
+            ) {
+                // 取消默认行为
+                e.preventDefault()
+                // 执行事件
+                // 恢复
+                editor.history.restore()
+            }
+        })
+        
         // tab up
         $textElem.on('keyup', (e: KeyboardEvent) => {
             if (e.keyCode !== 9) return


### PR DESCRIPTION
## 遇到了什么问题

*在使用撤销后使用Ctrl+Y键不能恢复，与Ctrl+Z经常搭配使用的快捷键不应当缺席*

## 你的预期是什么

*Ctrl+z撤销后 使用Ctrl+Y可以撤销刚才的撤销 也就是恢复*

## 是否进行了详细的自测？

*是*