### PR TITLE
fix: 视频上传逻辑和图片保持一致

### DIFF
--- a/src/menus/video/index.ts
+++ b/src/menus/video/index.ts
@@ -5,20 +5,39 @@
 
 import $ from '../../utils/dom-core'
 import Panel from '../menu-constructors/Panel'
+import { EMPTY_FN } from '../../utils/const'
 import Editor from '../../editor/index'
 import PanelMenu from '../menu-constructors/PanelMenu'
 import { MenuActive } from '../menu-constructors/Menu'
-import createPanelConf from './create-panel-conf'
+import createPanelConf, { VideoPanelConf } from './create-panel-conf'
 import bindEvent from './bind-event/index'
 
 class Video extends PanelMenu implements MenuActive {
+    private videoPanelConfig: VideoPanelConf
+
     constructor(editor: Editor) {
-        const $elem = $(
+        let $elem = $(
             `<div class="w-e-menu" data-title="视频">
                 <i class="w-e-icon-play"></i>
             </div>`
         )
+
+        let videoPanelConfig = createPanelConf(editor)
+        if (videoPanelConfig.onlyUploadConf) {
+            $elem = videoPanelConfig.onlyUploadConf.$elem
+            videoPanelConfig.onlyUploadConf.events.map(event => {
+                const type = event.type
+                const fn = event.fn || EMPTY_FN
+                $elem.on(type, (e: Event) => {
+                    e.stopPropagation()
+                    fn(e)
+                })
+            })
+        }
+
         super($elem, editor)
+
+        this.videoPanelConfig = videoPanelConfig
 
         // 绑定事件 tootip
         bindEvent(editor)
@@ -28,24 +47,26 @@ class Video extends PanelMenu implements MenuActive {
      * 菜单点击事件
      */
     public clickHandler(): void {
-        // 弹出 panel
-        this.createPanel('')
+        if (!this.videoPanelConfig.onlyUploadConf) {
+            this.createPanel()
+        }
     }
 
     /**
      * 创建 panel
      * @param link 链接
      */
-    private createPanel(iframe: string): void {
-        const conf = createPanelConf(this.editor, iframe)
+    private createPanel(): void {
+        const conf = this.videoPanelConfig
         const panel = new Panel(this, conf)
+        this.setPanel(panel)
         panel.create()
     }
 
     /**
      * 尝试修改菜单 active 状态
      */
-    public tryChangeActive() {}
+    public tryChangeActive() { }
 }
 
 export default Video


### PR DESCRIPTION
图片和视频上传有两种模式: 本地上传和网络链接

图片在设置 `showLinkImg = false` 后，点击菜单上的图片 icon, 可以直接选择文件。

如下: 直接点击图片菜单，弹出选择文件
![image](https://user-images.githubusercontent.com/22864183/140616701-c314cf31-0bf9-4bc3-b0b9-cba924150157.png)


然而视频在设置 `showLinkVideo = false` 后，点击视频菜单，还会弹出面板，让选择本地视频。

![image](https://user-images.githubusercontent.com/22864183/140616631-52987803-7b5d-4f9a-84c5-8d2724229cba.png)
 