### PR TITLE
Fix height handle 20220114

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ editor.create();
 - 164999061（人已满）
 - 710646022（人已满）
 - 901247714（人已满）
-- 606602511
+- 606602511（人已满）
+- 764778054
 
 提交 bug 或建议
 - [github issues](https://github.com/wangeditor-team/wangeditor/issues) 提交问题

--- a/src/editor/init-fns/set-full-screen.ts
+++ b/src/editor/init-fns/set-full-screen.ts
@@ -7,6 +7,7 @@ import Editor from '../index'
 import $ from '../../utils/dom-core'
 
 import '../../assets/style/full-screen.less'
+import { handlePx } from '../../utils/util';
 
 const iconFullScreenText = 'w-e-icon-fullscreen' // 全屏icon class
 const iconExitFullScreenText = 'w-e-icon-fullscreen_exit' // 退出全屏icon class
@@ -46,7 +47,7 @@ export const setUnFullScreen = (editor: Editor) => {
     $iconElem.addClass(iconFullScreenText)
     $editorParent.removeClass(classfullScreenEditor)
     $editorParent.css('z-index', 'auto')
-    $textContainerElem.css('height', config.height + 'px')
+    $textContainerElem.css('height', handlePx(config.height))
 }
 
 /**

--- a/src/menus/menu-constructors/DropList.ts
+++ b/src/menus/menu-constructors/DropList.ts
@@ -5,6 +5,7 @@
 import $, { DomElement } from '../../utils/dom-core'
 import DropListMenu from './DropListMenu'
 import { EMPTY_FN } from '../../utils/const'
+import { handlePx } from '../../utils/util';
 
 export type DropListItem = {
     $elem: DomElement
@@ -108,7 +109,7 @@ class DropList {
             // 加入 DOM 之前先定位位置
             const menuHeight = $menuELem.getBoundingClientRect().height || 0
             const width = this.conf.width || 100 // 默认为 100
-            $container.css('margin-top', menuHeight + 'px').css('width', width + 'px')
+            $container.css('margin-top', handlePx(menuHeight)).css('width', handlePx(width))
 
             // 加入到 DOM
             $menuELem.append($container)

--- a/src/menus/menu-constructors/Panel.ts
+++ b/src/menus/menu-constructors/Panel.ts
@@ -6,6 +6,7 @@
 import $, { DomElement } from '../../utils/dom-core'
 import PanelMenu from './PanelMenu'
 import { EMPTY_FN } from '../../utils/const'
+import { handlePx } from '../../utils/util';
 
 // Panel 配置格式
 export type TabEventConf = {
@@ -77,7 +78,7 @@ class Panel {
         }
 
         $container
-            .css('width', width + 'px')
+            .css('width', handlePx(width))
             .css('margin-top', `${top}px`)
             .css('margin-left', `${left}px`)
             .css('z-index', menu.editor.zIndex.get('panel'))
@@ -97,7 +98,7 @@ class Panel {
         // 设置高度
         const height = conf.height // height: 0 即不用设置
         if (height) {
-            $tabContentContainer.css('height', height + 'px').css('overflow-y', 'auto')
+            $tabContentContainer.css('height', handlePx(height)).css('overflow-y', 'auto')
         }
 
         // tabs

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -112,7 +112,7 @@ export function forEach<T extends unknown[] | Obj | ArrObj>(
  * @param fakeArr 类数组
  * @param fn 回调函数
  */
-export function arrForEach<T extends { length: number; [key: number]: unknown }>(
+export function arrForEach<T extends { length: number;[key: number]: unknown }>(
     fakeArr: T,
     fn: (this: T, item: T[number], index: number) => boolean | unknown
 ): void {
@@ -236,4 +236,12 @@ export function hexToRgb(hex: string) {
     const b = colors[3]
 
     return `rgb(${r}, ${g}, ${b})`
+}
+/**
+ * 处理设置的像素值
+ * @param unit string | number  500 || '500px' || '50vh' || '50%'
+ */
+export function handlePx(unit: string | number): string {
+    if (typeof unit === 'number') return unit + 'px'
+    return unit
 }

--- a/test/unit/editor/full-screen-unset.test.ts
+++ b/test/unit/editor/full-screen-unset.test.ts
@@ -1,6 +1,7 @@
 import createEditor, { selector } from '../../helpers/create-editor'
 import { setFullScreen, setUnFullScreen } from '../../../src/editor/init-fns/set-full-screen'
 import $ from 'jquery'
+import { handlePx } from '../../../src/utils/util';
 
 const EDIT_CONTAINER_FULLSCREEN_CLASS = 'w-e-full-screen-editor'
 
@@ -19,5 +20,5 @@ test.only('调用 setUnFullScreen 取消编辑器全屏模式', () => {
     expect($iconElem.get(0).className).toContain('w-e-icon-fullscreen')
     expect($editorParent.className).not.toContain(EDIT_CONTAINER_FULLSCREEN_CLASS)
     expect($editorParent.style.zIndex).toBe('auto')
-    expect($textContainerElem.elems[0].style.height).toBe(editor.config.height + 'px')
+    expect($textContainerElem.elems[0].style.height).toBe(handlePx(editor.config.height))
 })


### PR DESCRIPTION
**遇到的问题**
设置高度时无法使用相对单位，比如“50%“、“50vh“等
**我做的改动**
将高度单位 height +'px' 改成了 如果是number类型就 +'px'，如果是字符串类型就不+ 'px'
**是否经过完善的测试**
是的，望通过