### PR TITLE
修复placeholder class与Bootstrap 5冲突

### DIFF
--- a/src/assets/style/text.less
+++ b/src/assets/style/text.less
@@ -10,7 +10,7 @@
         height: 1px;
     }
 
-    .placeholder {
+    .w-e-placeholder {
         color: #D4D4D4;
         position: absolute;
         font-size: 11pt;

--- a/src/editor/init-fns/init-dom.ts
+++ b/src/editor/init-fns/init-dom.ts
@@ -67,7 +67,7 @@ export default function (editor: Editor): void {
     } else {
         $placeholder = $(`<div>${i18next.t(placeholder)}</div>`)
     }
-    $placeholder.addClass('placeholder')
+    $placeholder.addClass('w-e-placeholder')
 
     // 初始化编辑区域内容
     if ($children && $children.length) {

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -115,7 +115,7 @@ class Text {
      */
     public togglePlaceholder(): void {
         const html = this.html()
-        const $placeholder = this.editor.$textContainerElem.find('.placeholder')
+        const $placeholder = this.editor.$textContainerElem.find('.w-e-placeholder')
         $placeholder.hide()
         if (this.editor.isComposing) return
         if (!html || html === ' ') $placeholder.show()

--- a/test/unit/text/index.test.ts
+++ b/test/unit/text/index.test.ts
@@ -62,8 +62,8 @@ describe('Editor Text test', () => {
 
     test('编辑器初始化后，调用 txt togglePlaceholder 如果 editor txt 没有 html 内容则会展示 placeholder', () => {
         editor.txt.togglePlaceholder()
-        expect(editor.$textContainerElem.find('.placeholder').elems[0]).not.toBeUndefined()
-        expect(editor.$textContainerElem.find('.placeholder').elems[0]).toHaveStyle('display:block')
+        expect(editor.$textContainerElem.find('.w-e-placeholder').elems[0]).not.toBeUndefined()
+        expect(editor.$textContainerElem.find('.w-e-placeholder').elems[0]).toHaveStyle('display:block')
     })
 
     test('编辑器初始化后，调用 txt togglePlaceholder 如果 editor txt 有 html 内容则不展示 placeholder', () => {
@@ -71,7 +71,7 @@ describe('Editor Text test', () => {
 
         editor.txt.togglePlaceholder()
 
-        expect(editor.$textContainerElem.find('.placeholder').elems[0]).toHaveStyle('display:none')
+        expect(editor.$textContainerElem.find('.w-e-placeholder').elems[0]).toHaveStyle('display:none')
     })
 
     test('编辑器初始化后，调用 txt clear 方法，清空编辑内容，只留下 EMPTY_P', () => {


### PR DESCRIPTION
避免与Bootstrap 5发生冲突，造成placholder讯息变成灰色方块