### PR TITLE
优化：去掉table第一行默认3像素的右侧边框

### DIFF
--- a/packages/table-module/src/module/render-elem/render-cell.tsx
+++ b/packages/table-module/src/module/render-elem/render-cell.tsx
@@ -95,7 +95,6 @@ function renderTableCell(
     <Tag
       colSpan={colSpan}
       rowSpan={rowSpan}
-      style={{ borderRightWidth: '3px' }}
       on={{
         mousemove: throttle(function (this: VNode, event: MouseEvent) {
           const elem = this.elm as HTMLElement


### PR DESCRIPTION
默认插入一个新的table会在第一行自带borderRight:3px， 在render-cell.ts中：style={{ borderRightWidth: '3px' }}