### PR TITLE
fix: HeaderSelectMenu支持以i18n方式自定义标题下拉菜单中H1-H5渲染内容

### DIFF
--- a/packages/basic-modules/src/locale/zh-CN.ts
+++ b/packages/basic-modules/src/locale/zh-CN.ts
@@ -43,6 +43,11 @@ export default {
   header: {
     title: '标题',
     text: '正文',
+    header1: 'H1',
+    header2: 'H2',
+    header3: 'H3',
+    header4: 'H4',
+    header5: 'H5',
   },
   image: {
     netImage: '网络图片',

--- a/packages/basic-modules/src/modules/header/menu/HeaderSelectMenu.ts
+++ b/packages/basic-modules/src/modules/header/menu/HeaderSelectMenu.ts
@@ -19,27 +19,27 @@ class HeaderSelectMenu implements ISelectMenu {
       // value 和 elemNode.type 对应
       {
         value: 'header1',
-        text: 'H1',
+        text: t('header.header1'),
         styleForRenderMenuList: { 'font-size': '32px', 'font-weight': 'bold' },
       },
       {
         value: 'header2',
-        text: 'H2',
+        text: t('header.header2'),
         styleForRenderMenuList: { 'font-size': '24px', 'font-weight': 'bold' },
       },
       {
         value: 'header3',
-        text: 'H3',
+        text: t('header.header3'),
         styleForRenderMenuList: { 'font-size': '18px', 'font-weight': 'bold' },
       },
       {
         value: 'header4',
-        text: 'H4',
+        text: t('header.header4'),
         styleForRenderMenuList: { 'font-size': '16px', 'font-weight': 'bold' },
       },
       {
         value: 'header5',
-        text: 'H5',
+        text: t('header.header5'),
         styleForRenderMenuList: { 'font-size': '13px', 'font-weight': 'bold' },
       },
       { value: 'paragraph', text: t('header.text') },


### PR DESCRIPTION
功能：HeaderSelectMenu下拉列表支持以i18n方式自定义H1-H5渲染内容

使用：可通过 i18n 修改header1、header2...header5在菜单中渲染内容，默认渲染仍为H1、H2...H5

参考issue：  https://github.com/wangeditor-team/wangEditor/issues/4555