### PR TITLE
feat: Panel打开时滚动定位到当前已选项

### DIFF
--- a/packages/core/src/menus/panel-and-modal/BaseClass.ts
+++ b/packages/core/src/menus/panel-and-modal/BaseClass.ts
@@ -53,6 +53,17 @@ abstract class PanelAndModal {
     $menuElem.append($elem)
   }
 
+  // 尝试滚动到选中选项位置
+  scrollToSelectedItem() {
+    try {
+      const { $elem } = this
+      const target = $elem.find('li.selected')[0] as HTMLElement
+      $elem[0].scrollTo(0, target.offsetTop)
+    } catch {
+      console.info('skip scrollToSelectedItem')
+    }
+  }
+
   show() {
     if (this.isShow) return
     this.showTime = Date.now()
@@ -60,6 +71,7 @@ abstract class PanelAndModal {
     const { $elem } = this
     $elem.show()
     this.isShow = true
+    this.scrollToSelectedItem()
 
     // 触发事件
     const editor = PANEL_OR_MODAL_TO_EDITOR.get(this)


### PR DESCRIPTION
背景：默认无滚动，当选项较多时，再次定位已选选项，需多次滚动才可找到。

优化：显示弹框时滚动到已选选项，减少用户操作。

效果图：
![autoScroll](https://user-images.githubusercontent.com/19330620/196146132-124fc445-42c7-422e-abbc-939ffb27094d.gif)
