### PR TITLE
fix(ci): 修复因 node 版本过低导致第三方包可选链语法不支持的问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
           registry-url: https://registry.npmjs.com
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v2
       with:
-        node-version: 12.x
+        node-version: 14.x
         registry-url: https://registry.npmjs.com
     - name: Install dependencies
       run: yarn run bootstrap


### PR DESCRIPTION
CI 任务：https://github.com/wangeditor-team/wangEditor/actions/runs/3353870191 报错，发现是因为第三方包升级代码增加了可选链语法导致的问题。