### PR TITLE
fix: scrollToElem problem

### DIFF
--- a/packages/core/src/editor/plugins/with-dom.ts
+++ b/packages/core/src/editor/plugins/with-dom.ts
@@ -125,7 +125,7 @@ export const withDOM = <T extends Editor>(editor: T) => {
       return
     }
 
-    const $elem = $(`#${id}`)
+    const $elem = $(`[data-slate-editor] #${id}`)[0]
     if ($elem.length === 0) return
 
     // $elem 不在 editor DOM 范围之内


### PR DESCRIPTION
scrollToElem方法中，直接使用id选择器时，如果其他页面存在相同id，则会出现报错无法正确滚动
（虽然同一页面多个相同id使用是不正确的，但是仍然很容易就被不知情的开发人员触发）
所以把id的选取范围限定在了[data-slate-editor] 中