### PR TITLE
fix: 拖拽页面上的img元素到编辑器内变成超链接

### DIFF
--- a/packages/basic-modules/src/modules/link/plugin.ts
+++ b/packages/basic-modules/src/modules/link/plugin.ts
@@ -32,6 +32,12 @@ function withLink<T extends IDomEditor>(editor: T): T {
       return
     }
 
+    // 单图插入
+    if (/<img[^>]+>/.test(data.getData('text/html'))) {
+      insertData(data)
+      return
+    }
+
     // 插入链接
     if (isMenuDisabled(newEditor)) return // disabled
     const { selection } = newEditor


### PR DESCRIPTION
fix #5156 

在拖拽图片进入的时候因为src被解析出来，当作超链接插入了，在为链接的时候对html数据做一层判断