### PR TITLE
fix: demo中多个编辑器全屏显示层叠的问题

### DIFF
--- a/packages/editor/demo/multi-editor.html
+++ b/packages/editor/demo/multi-editor.html
@@ -25,14 +25,14 @@
 
       <div style="display: flex;">
         <div style="flex: 1">
-          <div style="border: 1px solid #ccc; margin-right: 5px;">
+          <div style="border: 1px solid #ccc; margin-right: 5px; z-index: 1;">
             <div id="editor-toolbar-1" style="border-bottom: 1px solid #ccc;"></div>
             <div id="editor-text-area-1" style="height: 400px;"></div>
           </div>
           <div id="content-view-1" class="editor-content-view"></div>
         </div>
         <div style="flex: 1">
-          <div style="border: 1px solid #ccc; margin-left: 5px;">
+          <div style="border: 1px solid #ccc; margin-left: 5px; z-index: 1;">
             <div id="editor-toolbar-2" style="border-bottom: 1px solid #ccc;"></div>
             <div id="editor-text-area-2" style="height: 400px;"></div>
           </div>


### PR DESCRIPTION
**问题描述：**

demo中多个编辑器全屏显示，只有最后一个正常显示，前面的因为z-index原因，出现层叠 [问题页面](https://www.wangeditor.com/demo/multi-editor.html)

**问题截图：**

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/75007029/210310087-21ada48a-84cc-42a0-8912-d001626a4907.png">

**问题修复：**

父元素添加 z-index属性后，正常显示，如下

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/75007029/210310586-d1652b63-681f-491e-a5b9-7459fc49c8d8.png">

