### PR TITLE
fix: 修复 node 判断

### DIFF
--- a/packages/editor/src/utils/node-polyfill.ts
+++ b/packages/editor/src/utils/node-polyfill.ts
@@ -6,7 +6,7 @@
 // @ts-nocheck
 
 // 必须是 node 环境
-if (typeof global === 'object') {
+if (typeof window === 'undefined') {
   // 用于 nodejs ，避免报错
   const globalProperty = Object.getOwnPropertyDescriptor(global, 'window')
 


### PR DESCRIPTION
解决微信浏览器报错`Cannot set property navigator of #<Window> which has only a getter`
复现方法：react 项目 global 为 object，可以使用 create-react-app 或者 umi 初始化项目，打印 typeof global。
