### PR TITLE
fix: 修复部分Android系统浏览器被判断为Safari的问题

### DIFF
--- a/packages/core/src/utils/ua.ts
+++ b/packages/core/src/utils/ua.ts
@@ -19,7 +19,7 @@ export const IS_FIREFOX_LEGACY =
   /^(?!.*Seamonkey)(?=.*Firefox\/(?:[0-7][0-9]|[0-8][0-6])(?:\.)).*/i.test(navigator.userAgent)
 
 export const IS_SAFARI =
-  typeof navigator !== 'undefined' && /Version\/[\d\.]+.*Safari/.test(navigator.userAgent) // eslint-disable-line
+  typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent) // eslint-disable-line
 
 // "modern" Edge was released at 79.x
 export const IS_EDGE_LEGACY =


### PR DESCRIPTION
在测试中发现有部分的Android手机的navigator.userAgent如下：

> Mozilla/5.0(Linux; U; Android 11; zh-cn;PCGM00 Build/RKQ1.201217.002)AppleWebKit/537.36(KHTML, like Gecko)Version/4.0 Chrome/90.0.4430.61 Mobile Safari/537.36 HeyTapBrowser/40.8.18.1.1

该手机型号是：OPPO K3，它的自带浏览器并不是 Safari，但是判断成了  Safari
