### PR TITLE
fix: 解决用户在插入链接时，如果没有填写链接地址，无法自定义给出错误提示的问题

### DIFF
--- a/packages/basic-modules/src/modules/link/helper.ts
+++ b/packages/basic-modules/src/modules/link/helper.ts
@@ -88,6 +88,10 @@ function genLinkNode(url: string, text?: string): LinkElement {
  * @param url url
  */
 export async function insertLink(editor: IDomEditor, text: string, url: string) {
+  // 校验
+  const checkRes = await check('insertLink', editor, text, url)
+  if (!checkRes) return // 校验未通过
+
   if (!url) return
   if (!text) text = url // 无 text 则用 url 代替
 
@@ -95,10 +99,6 @@ export async function insertLink(editor: IDomEditor, text: string, url: string) 
   editor.restoreSelection()
 
   if (isMenuDisabled(editor)) return
-
-  // 校验
-  const checkRes = await check('insertLink', editor, text, url)
-  if (!checkRes) return // 校验未通过
 
   // 转换 url
   const parsedUrl = await parse('insertLink', editor, url)
@@ -142,11 +142,11 @@ export async function insertLink(editor: IDomEditor, text: string, url: string) 
  * @param url link url
  */
 export async function updateLink(editor: IDomEditor, text: string, url: string) {
-  if (!url) return
-
   // 校验
   const checkRes = await check('editLink', editor, text, url)
   if (!checkRes) return // 校验未通过
+
+  if (!url) return
 
   // 转换 url
   const parsedUrl = await parse('editLink', editor, url)


### PR DESCRIPTION
问题复现步骤：
1.给insertLink加上自定义校验函数checkLink，在不输入链接地址时，函数无法触发

查看源码后发现，代码检测到没有url时，直接就return了，不会执行自定义校验函数，故改变代码执行顺序
