### PR TITLE
fix( table-module issue 4376): 修复 点击 table 左边边缘处报错无效 slate

### DIFF
--- a/packages/table-module/src/module/render-elem/render-table.tsx
+++ b/packages/table-module/src/module/render-elem/render-table.tsx
@@ -58,6 +58,7 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
     <div
       className="table-container"
       data-selected={selected}
+      contentEditable={false}
       on={{
         mousedown: (e: MouseEvent) => {
           // @ts-ignore 阻止光标定位到 table 后面


### PR DESCRIPTION
相关issue https://github.com/wangeditor-team/wangEditor/issues/4376

还有更多相关issue，待合并后关闭

相关 slate issue https://github.com/ianstormtaylor/slate/issues/3421