### PR TITLE
fix( table-module issue 4376): 修复 点击 table 左边边缘处报错无效 slate

### DIFF
--- a/packages/table-module/src/module/render-elem/render-table.tsx
+++ b/packages/table-module/src/module/render-elem/render-table.tsx
@@ -81,7 +81,7 @@ function renderTable(elemNode: SlateElement, children: VNode[] | null, editor: I
       }}
     >
       <table width={width} contentEditable={editable}>
-        <colgroup>
+        <colgroup contentEditable={false}>
           {firstRowCells.map(cell => {
             const { width = 'auto' } = cell
             return <col width={width}></col>


### PR DESCRIPTION
相关issue https://github.com/wangeditor-team/wangEditor/issues/4376

还有更多相关issue，待合并后关闭

相关 slate issue https://github.com/ianstormtaylor/slate/issues/3421

之前也提了个pr，但是后续测试有问题 https://github.com/wangeditor-team/wangEditor/pull/5829
这次过了一遍单元测试已经手动点击测试